### PR TITLE
Strip symbols from executable file to reduce size

### DIFF
--- a/cmd/gokr-packer/buildinit.go
+++ b/cmd/gokr-packer/buildinit.go
@@ -106,7 +106,8 @@ func buildInit(bins map[string]string) (tmpdir string, err error) {
 		return "", err
 	}
 
-	cmd := exec.Command("go", "build", "-o", filepath.Join(tmpdir, "init"), code.Name())
+	cmd := exec.Command("go", "build", "-ldflags", "-s -w",
+		"-o", filepath.Join(tmpdir, "init"), code.Name())
 	cmd.Env = env
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/cmd/gokr-packer/gotool.go
+++ b/cmd/gokr-packer/gotool.go
@@ -68,7 +68,10 @@ func install() error {
 	}
 
 	cmd = exec.Command("go",
-		append([]string{"install", "-tags", "gokrazy"}, pkgs...)...)
+		append([]string{"install",
+			"-tags", "gokrazy",
+			"-ldflags", "-s -w",
+		}, pkgs...)...)
 	cmd.Env = env
 	cmd.Stderr = os.Stderr
 	return cmd.Run()


### PR DESCRIPTION
Strip symbols from executable file to reduce size by adding ldflags to "go install" and "go build" command.

Before this commit

$ ls -lh
total 15M
-r--r--r-- 1 koba koba 2.9M Mar 29 05:33 dhcp
-r--r--r-- 1 koba koba 8.8M Mar 29 05:33 init
-r--r--r-- 1 koba koba 3.3M Mar 29 05:33 ntp

15.0 MB in total

After this commit
$ ls -lh
total 9.0M
-r--r--r-- 1 koba koba 1.7M Mar 29 05:47 dhcp
-r--r--r-- 1 koba koba 5.4M Mar 29 05:47 init
-r--r--r-- 1 koba koba 2.0M Mar 29 05:47 ntp

9.1 MB in total
