### PR TITLE
cmd/gokr-packer: add missing rereadPartitions for darwin

### DIFF
--- a/cmd/gokr-packer/parttable_darwin.go
+++ b/cmd/gokr-packer/parttable_darwin.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -25,4 +26,8 @@ func deviceSize(fd uintptr) (uint64, error) {
 	}
 
 	return uint64(blocksize) * blockcount, nil
+}
+
+func rereadPartitions(fd uintptr) error {
+	return fmt.Errorf("gokrazy is currently missing code for re-reading partition tables on your operating system. Please see the README at https://github.com/gokrazy/tools for alternatives, and consider contributing code to fix this")
 }


### PR DESCRIPTION
This change makes it possible to use the combination of gokr-packer and
image manipulation tools like balena Ethcer on macOS.