### PR TITLE
Packer part of gokrazy/gokrazy#7

### DIFF
--- a/cmd/gokr-packer/certs.go
+++ b/cmd/gokr-packer/certs.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gokrazy/internal/config"
+)
+
+func generateAndSignCert() ([]byte, *rsa.PrivateKey, error) {
+	notBefore := time.Now()
+	notAfter := notBefore.Add(2 * 365 * 24 * time.Hour)
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, nil, err
+	}
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"gokrazy"},
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{*hostname},
+	}
+	priv, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, err
+	}
+	pub := &priv.PublicKey
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, pub, priv)
+	if err != nil {
+		return nil, nil, err
+	}
+	return derBytes, priv, err
+}
+func generateAndStoreSelfSignedCertificate(hostConfigPath, certPath, keyPath string) error {
+	fmt.Println("Generating new self-signed certificate...")
+	// Generate
+	if err := os.MkdirAll(string(hostConfigPath), 0755); err != nil {
+		return err
+	}
+	cert, priv, err := generateAndSignCert()
+	if err != nil {
+		return err
+	}
+
+	// Write Certificate
+	certOut, err := os.OpenFile(certPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: cert}); err != nil {
+		return err
+	}
+	if err := certOut.Close(); err != nil {
+		return err
+	}
+
+	// Write Key
+	keyOut, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return err
+	}
+	if err := pem.Encode(keyOut, &pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}); err != nil {
+		//TODO: Cleanup?
+		return err
+	}
+	if err := keyOut.Close(); err != nil {
+		//TODO: Cleanup?
+		return err
+	}
+	return nil
+}
+
+func getCertificate() (string, string, error) {
+	hostConfigPath := config.HostnameSpecific(*hostname)
+	var certPath, keyPath string
+	switch *useTLS {
+	case "self-signed":
+		certPath = filepath.Join(string(hostConfigPath), "cert.pem")
+		keyPath = filepath.Join(string(hostConfigPath), "key.pem")
+		gen := false
+		exist := true
+		if _, err := os.Stat(certPath); os.IsNotExist(err) {
+			gen = true
+			exist = false
+		}
+		if _, err := os.Stat(keyPath); os.IsNotExist(err) {
+			gen = true
+			exist = false
+		}
+		if exist {
+			// TODO: Check validity dates of existing certificate
+		}
+		if gen {
+			if err := generateAndStoreSelfSignedCertificate(string(hostConfigPath), certPath, keyPath); err != nil {
+				return "", "", err
+			}
+		}
+	case "":
+		return "", "", nil
+	default:
+		parts := strings.Split(*useTLS, ",")
+		certPath = parts[0]
+		if len(parts) > 1 {
+			keyPath = parts[1]
+		} else {
+			return "", "", fmt.Errorf("no private key supplied")
+		}
+		// TODO: Check validity
+	}
+	return certPath, keyPath, nil
+}
+
+func getCertificateFromFile(certPath string) (*x509.Certificate, error) {
+	reader, err := ioutil.ReadFile(certPath)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(reader)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	return cert, nil
+}
+
+func getCertificateFingerprintSHA1(certificate *x509.Certificate) [sha1.Size]byte {
+	return sha1.Sum(certificate.Raw)
+}

--- a/cmd/gokr-packer/packer.go
+++ b/cmd/gokr-packer/packer.go
@@ -472,7 +472,7 @@ func logic() error {
 
 		updateHttpClient, foundMatchingCertificate, err = httpclient.GetTLSHttpClientByTLSFlag(useTLS, updateBaseUrl)
 		if err != nil {
-			return fmt.Errorf("gettting http client by tls flag: %v", err)
+			return fmt.Errorf("getting http client by tls flag: %v", err)
 		}
 		remoteScheme, err := httpclient.GetRemoteScheme(updateBaseUrl)
 		if remoteScheme == "https" {

--- a/cmd/gokr-packer/packer.go
+++ b/cmd/gokr-packer/packer.go
@@ -435,6 +435,13 @@ func logic() error {
 	if deployCertFile != "" {
 		// User requested TLS
 		schema = "https"
+		if *tlsInsecure {
+			// If -insecure is specified, use http instead of https to make the
+			// process of updating to non-empty -tls= a bit smoother.
+		} else {
+			schema = "https"
+		}
+
 		ssl.dirents = append(ssl.dirents, &fileInfo{
 			filename: "gokrazy-web.pem",
 			fromHost: deployCertFile,

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.14
 
 require (
 	github.com/gokrazy/gokrazy v0.0.0-20200527062450-9e57e3cf2ee6
-	github.com/gokrazy/internal v0.0.0-20200530170418-389acc6d0821
+	github.com/gokrazy/internal v0.0.0-20200531194636-d96421c60091
 	golang.org/x/sys v0.0.0-20200523222454-059865788121
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/gokrazy/internal v0.0.0-20200530170418-389acc6d0821 h1:H8TFA9ZURF3PrJ
 github.com/gokrazy/internal v0.0.0-20200530170418-389acc6d0821/go.mod h1:LA5TQy7LcvYGQOy75tkrYkFUhbV2nl5qEBP47PSi2JA=
 github.com/gokrazy/internal v0.0.0-20200530185935-5369c1985e1f h1:wxp19JCv3nP5KrfYr8bIuSnmQUzvSzmUO+9gyk/Hwys=
 github.com/gokrazy/internal v0.0.0-20200530185935-5369c1985e1f/go.mod h1:LA5TQy7LcvYGQOy75tkrYkFUhbV2nl5qEBP47PSi2JA=
+github.com/gokrazy/internal v0.0.0-20200531194636-d96421c60091 h1:gP2Z4WgsQl35mlNf4kqYW0D8KnYMC4kdsczagvVKBbg=
+github.com/gokrazy/internal v0.0.0-20200531194636-d96421c60091/go.mod h1:LA5TQy7LcvYGQOy75tkrYkFUhbV2nl5qEBP47PSi2JA=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gopacket v1.1.16/go.mod h1:UCLx9mCmAwsVbn6qQl1WIEt2SO7Nd2fD0th1TBAsqBw=
 github.com/mdlayher/raw v0.0.0-20190303161257-764d452d77af/go.mod h1:rC/yE65s/DoHB6BzVOUBNYBGTg772JVytyAytffIZkY=


### PR DESCRIPTION
This PR adds a `-tls` option to the packer, which

1. Generates a self-signed certificate if `-tls=self-signd`
2. Packs the certificate into the image (`/etc/ssl/web.pem` and `/etc/ssl/web_key.pem`)

The updater pins the generated certificate in the local configuration and implements TLS stripping detection. Certificates can be pinned manually by placing them into the host specific configuration directory. Depends on [my pr for internal](https://github.com/gokrazy/internal/pull/4).