### PR TITLE
Support custom build args

### DIFF
--- a/cmd/gokr-packer/gotool.go
+++ b/cmd/gokr-packer/gotool.go
@@ -44,7 +44,7 @@ func goEnv() []string {
 		"GOBIN=")
 }
 
-func build(bindir string, buildArgsFileContents map[string]string) error {
+func build(bindir string, packageBuildFlags map[string]string) error {
 	pkgs := append(gokrazyPkgs, flag.Args()...)
 	if *initPkg != "" {
 		pkgs = append(pkgs, *initPkg)
@@ -97,8 +97,8 @@ func build(bindir string, buildArgsFileContents map[string]string) error {
 				"-tags", "gokrazy",
 				"-o", filepath.Join(bindir, filepath.Base(pkg.Target)),
 			}
-			if buildArgs := buildArgsFileContents[pkg.ImportPath]; buildArgs != "" {
-				args = append(args, buildArgs)
+			if buildFlags := packageBuildFlags[pkg.ImportPath]; buildFlags != "" {
+				args = append(args, buildFlags)
 			}
 			args = append(args, pkg.ImportPath)
 			cmd := exec.Command("go", args...)

--- a/cmd/gokr-packer/gotool.go
+++ b/cmd/gokr-packer/gotool.go
@@ -92,11 +92,16 @@ func build(bindir string) error {
 	for _, pkg := range mainPkgs {
 		pkg := pkg // copy
 		eg.Go(func() error {
-			cmd := exec.Command("go",
+			args := []string{
 				"build",
 				"-tags", "gokrazy",
 				"-o", filepath.Join(bindir, filepath.Base(pkg.Target)),
-				pkg.ImportPath)
+			}
+			if *buildArgs != "" {
+				args = append(args, *buildArgs)
+			}
+			args = append(args, pkg.ImportPath)
+			cmd := exec.Command("go", args...)
 			cmd.Env = env
 			cmd.Stderr = os.Stderr
 			if err := cmd.Run(); err != nil {

--- a/cmd/gokr-packer/gotool.go
+++ b/cmd/gokr-packer/gotool.go
@@ -44,7 +44,7 @@ func goEnv() []string {
 		"GOBIN=")
 }
 
-func build(bindir string) error {
+func build(bindir string, buildArgsFileContents map[string]string) error {
 	pkgs := append(gokrazyPkgs, flag.Args()...)
 	if *initPkg != "" {
 		pkgs = append(pkgs, *initPkg)
@@ -97,8 +97,8 @@ func build(bindir string) error {
 				"-tags", "gokrazy",
 				"-o", filepath.Join(bindir, filepath.Base(pkg.Target)),
 			}
-			if *buildArgs != "" {
-				args = append(args, *buildArgs)
+			if buildArgs := buildArgsFileContents[pkg.ImportPath]; buildArgs != "" {
+				args = append(args, buildArgs)
 			}
 			args = append(args, pkg.ImportPath)
 			cmd := exec.Command("go", args...)

--- a/cmd/gokr-packer/packer.go
+++ b/cmd/gokr-packer/packer.go
@@ -131,11 +131,10 @@ func findPackageFiles(fileType string) ([]string, error) {
 	})
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil // no package/ directory found
+			return nil, nil // no fileType directory found
 		}
 	}
 
-	// no package files found
 	return packageFilePaths, nil
 }
 
@@ -175,13 +174,13 @@ func findFlagFiles() (map[string]string, error) {
 	return contents, nil
 }
 
-func findBuildArgsFiles() (map[string]string, error) {
-	buildArgsFilePaths, err := findPackageFiles("buildargs")
+func findBuildFlagsFiles() (map[string]string, error) {
+	buildFlagsFilePaths, err := findPackageFiles("buildflags")
 	if err != nil {
 		return nil, err
 	}
 
-	if len(buildArgsFilePaths) == 0 {
+	if len(buildFlagsFilePaths) == 0 {
 		return nil, nil // no flags.txt files found
 	}
 
@@ -191,10 +190,10 @@ func findBuildArgsFiles() (map[string]string, error) {
 	}
 
 	contents := make(map[string]string)
-	for _, p := range buildArgsFilePaths {
-		pkg := strings.TrimSuffix(strings.TrimPrefix(p, "buildargs/"), "/buildargs.txt")
+	for _, p := range buildFlagsFilePaths {
+		pkg := strings.TrimSuffix(strings.TrimPrefix(p, "buildflags/"), "/buildflags.txt")
 		if !buildPackages[pkg] {
-			log.Printf("WARNING: buildargs file %s does not match any specified package (%s)", pkg, flag.Args())
+			log.Printf("WARNING: buildflags file %s does not match any specified package (%s)", pkg, flag.Args())
 			continue
 		}
 		log.Printf("package %s will be compiled with build args from %s", pkg, p)
@@ -463,12 +462,12 @@ func logic() error {
 	}
 	defer os.RemoveAll(tmp)
 
-	buildArgsFileContents, err := findBuildArgsFiles()
+	packageBuildArgs, err := findBuildFlagsFiles()
 	if err != nil {
 		return err
 	}
 
-	if err := build(tmp, buildArgsFileContents); err != nil {
+	if err := build(tmp, packageBuildArgs); err != nil {
 		return err
 	}
 

--- a/cmd/gokr-packer/packer.go
+++ b/cmd/gokr-packer/packer.go
@@ -56,6 +56,10 @@ var (
 		"",
 		"Go package to install as /gokrazy/init instead of the auto-generated one")
 
+	buildArgs = flag.String("build_args",
+		"",
+		"Build arguments to pass to Go for building the client application in addition to `-tags gokrazy`")
+
 	update = flag.String("update",
 		os.Getenv("GOKRAZY_UPDATE"),
 		`URL of a gokrazy installation (e.g. http://gokrazy:mypassword@myhostname/) to update. The special value "yes" uses the stored password and -hostname value to construct the URL`)

--- a/cmd/gokr-packer/packer.go
+++ b/cmd/gokr-packer/packer.go
@@ -196,7 +196,7 @@ func findBuildFlagsFiles() (map[string]string, error) {
 			log.Printf("WARNING: buildflags file %s does not match any specified package (%s)", pkg, flag.Args())
 			continue
 		}
-		log.Printf("package %s will be compiled with build args from %s", pkg, p)
+		log.Printf("package %s will be compiled with build flags from %s", pkg, p)
 
 		b, err := ioutil.ReadFile(p)
 		if err != nil {

--- a/cmd/gokr-packer/packer.go
+++ b/cmd/gokr-packer/packer.go
@@ -66,7 +66,7 @@ var (
 
 	hostname = flag.String("hostname",
 		"gokrazy",
-		"host name to set on the target system. Will be sent when acquiring DHCP leases")
+		"Host name to set on the target system. Will be sent when acquiring DHCP leases")
 
 	// TODO: Generate unique hostname on bootstrap e.g. gokrazy-<5-10 random characters>?
 	useTLS = flag.String("tls",
@@ -88,11 +88,11 @@ You can also create your own certificate-key-pair (e.g. by using https://github.
 			"github.com/gokrazy/gokrazy/cmd/ntp",
 			"github.com/gokrazy/gokrazy/cmd/randomd",
 		}, ","),
-		"comma-separated list of packages installed to /gokrazy/ (boot and system utilities)")
+		"Comma-separated list of packages installed to /gokrazy/ (boot and system utilities)")
 
 	sudo = flag.String("sudo",
 		"auto",
-		"whether to elevate privileges using sudo when required (one of auto, always, never, default auto)")
+		"Whether to elevate privileges using sudo when required (one of auto, always, never, default auto)")
 
 	httpPort = flag.String("http_port",
 		"80",

--- a/cmd/gokr-packer/packer.go
+++ b/cmd/gokr-packer/packer.go
@@ -462,12 +462,12 @@ func logic() error {
 	}
 	defer os.RemoveAll(tmp)
 
-	packageBuildArgs, err := findBuildFlagsFiles()
+	packageBuildFlags, err := findBuildFlagsFiles()
 	if err != nil {
 		return err
 	}
 
-	if err := build(tmp, packageBuildArgs); err != nil {
+	if err := build(tmp, packageBuildFlags); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fix https://github.com/gokrazy/gokrazy/issues/80

Doing something like 

    -build_args "-tags=release -ldflags '-X "github.com/andig/evcc/server.Version=foo" -X "github.com/andig/evcc/server.Commit=bar"'"

seems to work fine. I had expected needing to use something like https://github.com/kballard/go-shellquote or https://github.com/google/shlex but that doesn't seem required.