### PR TITLE
Custom extra files for rootfs

### DIFF
--- a/cmd/gokr-packer/packer.go
+++ b/cmd/gokr-packer/packer.go
@@ -191,7 +191,7 @@ func findFlagFiles() (map[string]string, error) {
 			continue
 		}
 		packageConfigFiles[pkg] = append(packageConfigFiles[pkg], packageConfigFile{
-			kind:         "started with command-line flags",
+			kind:         "be started with command-line flags",
 			path:         p.path,
 			lastModified: p.modTime,
 		})
@@ -228,7 +228,7 @@ func findBuildFlagsFiles() (map[string][]string, error) {
 			continue
 		}
 		packageConfigFiles[pkg] = append(packageConfigFiles[pkg], packageConfigFile{
-			kind:         "compiled with build flags",
+			kind:         "be compiled with build flags",
 			path:         p.path,
 			lastModified: p.modTime,
 		})
@@ -277,7 +277,7 @@ func findEnvFiles() (map[string]string, error) {
 			continue
 		}
 		packageConfigFiles[pkg] = append(packageConfigFiles[pkg], packageConfigFile{
-			kind:         "started with environment variables",
+			kind:         "be started with environment variables",
 			path:         p.path,
 			lastModified: p.modTime,
 		})
@@ -333,7 +333,7 @@ func addToFileInfo(parent *fileInfo, path string) (error, time.Time) {
 		} else {
 			// file overwrite is not supported -> return error
 			if !entry.IsDir() || fi.fromHost != "" || fi.fromLiteral != "" {
-				return fmt.Errorf("file alreayd exist in rootfs: %s", filepath.Join(path, entry.Name())), time.Time{}
+				return fmt.Errorf("file already exists in filesystem: %s", filepath.Join(path, entry.Name())), time.Time{}
 			}
 		}
 
@@ -370,7 +370,7 @@ func findExtraFiles() (map[string]*fileInfo, error) {
 		}
 
 		packageConfigFiles[pkg] = append(packageConfigFiles[pkg], packageConfigFile{
-			kind:         "started with extra files",
+			kind:         "include extra files in the root file system",
 			path:         path,
 			lastModified: latestModTime,
 		})
@@ -667,7 +667,7 @@ func logic() error {
 	for pkg, configFiles := range packageConfigFiles {
 		log.Printf("package %s:", pkg)
 		for _, configFile := range configFiles {
-			log.Printf("  will be %s",
+			log.Printf("  will %s",
 				configFile.kind)
 			log.Printf("    from %s",
 				configFile.path)

--- a/cmd/gokr-packer/packer.go
+++ b/cmd/gokr-packer/packer.go
@@ -801,9 +801,8 @@ func logic() error {
 
 	for pkg1, fs1 := range extraFiles {
 		// check against root fs
-		paths := getDuplication(root, fs1)
-		if len(paths) > 0 {
-			return fmt.Errorf("extra files of package %s collides with rootfs: %v", pkg1, paths)
+		if paths := getDuplication(root, fs1); len(paths) > 0 {
+			return fmt.Errorf("extra files of package %s collides with root file system: %v", pkg1, paths)
 		}
 
 		// check against other packages
@@ -811,14 +810,14 @@ func logic() error {
 			if pkg1 == pkg2 {
 				continue
 			}
-			paths = getDuplication(fs1, fs2)
-			if len(paths) > 0 {
+
+			if paths := getDuplication(fs1, fs2); len(paths) > 0 {
 				return fmt.Errorf("extra files of package %s collides with package %s: %v", pkg1, pkg2, paths)
 			}
 		}
 
 		// add extra files to rootfs
-		if err = root.combine(fs1); err != nil {
+		if err := root.combine(fs1); err != nil {
 			return fmt.Errorf("failed to add extra files from package %s: %v", pkg1, err)
 		}
 	}

--- a/cmd/gokr-packer/write.go
+++ b/cmd/gokr-packer/write.go
@@ -352,7 +352,7 @@ func (fi *fileInfo) pathList() (paths []string) {
 			paths = append(paths, path.Join(ent.filename, e))
 		}
 	}
-	return
+	return paths
 }
 
 func (fi *fileInfo) combine(fi2 *fileInfo) error {
@@ -536,5 +536,5 @@ func getDuplication(fiA, fiB *fileInfo) (paths []string) {
 		}
 		checkMap[p] = true
 	}
-	return
+	return paths
 }

--- a/cmd/gokr-packer/write.go
+++ b/cmd/gokr-packer/write.go
@@ -529,12 +529,12 @@ func writeMBR(f io.ReadSeeker, fw io.WriteSeeker, partuuid uint32) error {
 // getDuplication between the two given filesystems
 func getDuplication(fiA, fiB *fileInfo) (paths []string) {
 	allPaths := append(fiA.pathList(), fiB.pathList()...)
-	checkMap := make(map[string]struct{}, len(allPaths))
+	checkMap := make(map[string]bool, len(allPaths))
 	for _, p := range allPaths {
 		if _, ok := checkMap[p]; ok {
 			paths = append(paths, p)
 		}
-		checkMap[p] = struct{}{}
+		checkMap[p] = true
 	}
 	return
 }


### PR DESCRIPTION
This changes adds support to add extra files to the rootfs.
The definition is done similar to the flags, buildflags and env.

All files in the directory
```
./extrafiles/github.com/test/package/
```
will be added to the rootfs in
```
/
```

Currently it is not supported to overwrite files!

Here an example output for some extra files in `extrafiles/github.com/gokrazy/breakglass`:
```
2021/06/22 22:16:05 packer.go:670: package github.com/gokrazy/breakglass:
2021/06/22 22:16:05 packer.go:672:   will be started with command-line flags
2021/06/22 22:16:05 packer.go:674:     from flags/github.com/gokrazy/breakglass/flags.txt
2021/06/22 22:16:05 packer.go:676:     last modified: 2021-06-20T11:29:39+02:00 (58h46m26s ago)
2021/06/22 22:16:05 packer.go:672:   will include extra files in the root file system
2021/06/22 22:16:05 packer.go:674:     from extrafiles/github.com/gokrazy/breakglass
2021/06/22 22:16:05 packer.go:676:     last modified: 2021-06-22T16:55:17+02:00 (5h20m48s ago)
2021/06/22 22:16:05 packer.go:680: 
2021/06/22 22:16:06 packer.go:1201: extra files of package github.com/gokrazy/breakglass collides with rootfs: [etc/http-port.txt]
```
