### PR TITLE
packer: allow using MBR partition tables

### DIFF
--- a/cmd/gokr-packer/packer.go
+++ b/cmd/gokr-packer/packer.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -25,6 +26,7 @@ import (
 	// Imported so that the go tool will download the repositories
 	_ "github.com/gokrazy/gokrazy/empty"
 
+	"github.com/gokrazy/internal/deviceconfig"
 	"github.com/gokrazy/internal/httpclient"
 	"github.com/gokrazy/internal/humanize"
 	"github.com/gokrazy/internal/progress"
@@ -106,6 +108,12 @@ You can also create your own certificate-key-pair (e.g. by using https://github.
 	testboot = flag.Bool("testboot",
 		false,
 		"Trigger a testboot instead of switching to the new root partition directly")
+
+	deviceType = flag.String("device_type",
+		"",
+		`Device type identifier (defined in github.com/gokrazy/internal/deviceconfig) used for applying device-specific modifications to gokrazy.
+e.g. -device_type=odroidhc1 to apply MBR changes and device-specific bootloader files for Odroid XU4/HC1/HC2.
+Defaults to an empty string.`)
 )
 
 var gokrazyPkgs []string
@@ -466,11 +474,15 @@ func verifyNotMounted(dev string) error {
 	return nil
 }
 
-func (p *pack) overwriteDevice(dev string, root *fileInfo) error {
+func (p *pack) overwriteDevice(dev string, root *fileInfo, rootDeviceFiles []deviceconfig.RootFile) error {
 	if err := verifyNotMounted(dev); err != nil {
 		return err
 	}
-	log.Printf("partitioning %s (GPT + Hybrid MBR)", dev)
+	parttable := "GPT + Hybrid MBR"
+	if !p.UseGPT {
+		parttable = "no GPT, only MBR"
+	}
+	log.Printf("partitioning %s (%s)", dev, parttable)
 
 	f, err := p.partition(*overwrite)
 	if err != nil {
@@ -512,6 +524,10 @@ func (p *pack) overwriteDevice(dev string, root *fileInfo) error {
 		return err
 	}
 
+	if err := writeRootDeviceFiles(f, rootDeviceFiles); err != nil {
+		return err
+	}
+
 	if err := f.Close(); err != nil {
 		return err
 	}
@@ -545,7 +561,7 @@ func (ors *offsetReadSeeker) Seek(offset int64, whence int) (int64, error) {
 	return ors.ReadSeeker.Seek(offset, whence)
 }
 
-func (p *pack) overwriteFile(filename string, root *fileInfo) (bootSize int64, rootSize int64, err error) {
+func (p *pack) overwriteFile(filename string, root *fileInfo, rootDeviceFiles []deviceconfig.RootFile) (bootSize int64, rootSize int64, err error) {
 	f, err := os.Create(*overwrite)
 	if err != nil {
 		return 0, 0, err
@@ -591,6 +607,10 @@ func (p *pack) overwriteFile(filename string, root *fileInfo) (bootSize int64, r
 
 	var rs countingWriter
 	if _, err := io.Copy(io.MultiWriter(f, &rs), tmp); err != nil {
+		return 0, 0, err
+	}
+
+	if err := writeRootDeviceFiles(f, rootDeviceFiles); err != nil {
 		return 0, 0, err
 	}
 
@@ -712,6 +732,17 @@ func logic() error {
 	dontStart, err := findDontStart()
 	if err != nil {
 		return err
+	}
+
+	var mbrOnlyWithoutGpt bool
+	var rootDeviceFiles []deviceconfig.RootFile
+	if *deviceType != "" {
+		if cfg, ok := deviceconfig.GetDeviceConfigBySlug(*deviceType); ok {
+			rootDeviceFiles = cfg.RootDeviceFiles
+			mbrOnlyWithoutGpt = cfg.MBROnlyWithoutGPT
+		} else {
+			return fmt.Errorf("unknown device slug %q", *deviceType)
+		}
 	}
 
 	args := flag.Args()
@@ -889,12 +920,17 @@ func logic() error {
 		}
 	}
 
-	newInstallation := updateflag.NewInstallation()
 	p := pack{
 		Pack: packer.NewPackForHost(*hostname),
 	}
+
+	newInstallation := updateflag.NewInstallation()
+	useGPT := newInstallation && !mbrOnlyWithoutGpt
+
 	p.Pack.UsePartuuid = newInstallation
-	p.Pack.UseGPTPartuuid = newInstallation
+	p.Pack.UseGPTPartuuid = useGPT
+	p.Pack.UseGPT = useGPT
+
 	var (
 		updateHttpClient         *http.Client
 		foundMatchingCertificate bool
@@ -945,9 +981,11 @@ func logic() error {
 		}
 		p.UsePartuuid = target.Supports("partuuid")
 		p.UseGPTPartuuid = target.Supports("gpt")
+		p.UseGPT = target.Supports("gpt")
 	}
 	fmt.Printf("\n")
 	fmt.Printf("Feature summary:\n")
+	fmt.Printf("  use GPT: %v\n", p.UseGPT)
 	fmt.Printf("  use PARTUUID: %v\n", p.UsePartuuid)
 	fmt.Printf("  use GPT PARTUUID: %v\n", p.UseGPTPartuuid)
 
@@ -967,7 +1005,7 @@ func logic() error {
 		isDev = err == nil && st.Mode()&os.ModeDevice == os.ModeDevice
 
 		if isDev {
-			if err := p.overwriteDevice(*overwrite, root); err != nil {
+			if err := p.overwriteDevice(*overwrite, root, rootDeviceFiles); err != nil {
 				return err
 			}
 			fmt.Printf("To boot gokrazy, plug the SD card into a Raspberry Pi 3 or 4 (no other models supported)\n")
@@ -985,7 +1023,7 @@ func logic() error {
 				return fmt.Errorf("-target_storage_bytes must be at least %d (for boot + 2 root file systems + 100 MB /perm)", lower)
 			}
 
-			bootSize, rootSize, err = p.overwriteFile(*overwrite, root)
+			bootSize, rootSize, err = p.overwriteFile(*overwrite, root, rootDeviceFiles)
 			if err != nil {
 				return err
 			}
@@ -1203,46 +1241,36 @@ func logic() error {
 	prog := &progress.Reporter{}
 	go prog.Report(progctx)
 
-	{
-		start := time.Now()
-		prog.SetStatus("update root file system")
-		prog.SetTotal(0)
-		if stater, ok := rootReader.(interface{ Stat() (os.FileInfo, error) }); ok {
-			if st, err := stater.Stat(); err == nil {
-				prog.SetTotal(uint64(st.Size()))
-			}
-		}
-		// Start with the root file system because writing to the non-active
-		// partition cannot break the currently running system.
-		if err := target.StreamTo("root", io.TeeReader(rootReader, &progress.Writer{})); err != nil {
-			return fmt.Errorf("updating root file system: %v", err)
-		}
-		duration := time.Since(start)
-		transferred := progress.Reset()
-		fmt.Printf("\rTransferred root file system (%s) at %.2f MiB/s (total: %v)\n",
-			humanize.Bytes(transferred),
-			float64(transferred)/duration.Seconds()/1024/1024,
-			duration.Round(time.Second))
+	// Start with the root file system because writing to the non-active
+	// partition cannot break the currently running system.
+	if err := updateWithProgress(prog, rootReader, target, "root file system", "root"); err != nil {
+		return err
 	}
 
-	{
-		start := time.Now()
-		prog.SetStatus("update boot file system")
-		prog.SetTotal(0)
-		if stater, ok := bootReader.(interface{ Stat() (os.FileInfo, error) }); ok {
-			if st, err := stater.Stat(); err == nil {
-				prog.SetTotal(uint64(st.Size()))
+	kernelDir, err := packer.PackageDir(*kernelPackage)
+	if err != nil {
+		return err
+	}
+	for _, rootDeviceFile := range rootDeviceFiles {
+		f, err := os.Open(filepath.Join(kernelDir, rootDeviceFile.Name))
+		if err != nil {
+			return err
+		}
+
+		if err := updateWithProgress(
+			prog, f, target, fmt.Sprintf("root device file %s", rootDeviceFile.Name),
+			filepath.Join("device-specific", rootDeviceFile.Name),
+		); err != nil {
+			if errors.As(err, updater.ErrUpdateHandlerNotImplemented) {
+				log.Printf("target does not support updating device file %s yet, ignoring", rootDeviceFile.Name)
+				continue
 			}
+			return err
 		}
-		if err := target.StreamTo("boot", io.TeeReader(bootReader, &progress.Writer{})); err != nil {
-			return fmt.Errorf("updating boot file system: %v", err)
-		}
-		duration := time.Since(start)
-		transferred := progress.Reset()
-		fmt.Printf("\rTransferred boot file system (%s) at %.2f MiB/s (total: %v)\n",
-			humanize.Bytes(transferred),
-			float64(transferred)/duration.Seconds()/1024/1024,
-			duration.Round(time.Second))
+	}
+
+	if err := updateWithProgress(prog, bootReader, target, "boot file system", "boot"); err != nil {
+		return err
 	}
 
 	if err := target.StreamTo("mbr", mbrReader); err != nil {
@@ -1289,6 +1317,30 @@ func logic() error {
 		fmt.Printf("Device ready to use!\n")
 		break
 	}
+
+	return nil
+}
+
+func updateWithProgress(prog *progress.Reporter, reader io.Reader, target *updater.Target, logStr string, stream string) error {
+	start := time.Now()
+	prog.SetStatus(fmt.Sprintf("update %s", logStr))
+	prog.SetTotal(0)
+
+	if stater, ok := reader.(interface{ Stat() (os.FileInfo, error) }); ok {
+		if st, err := stater.Stat(); err == nil {
+			prog.SetTotal(uint64(st.Size()))
+		}
+	}
+	if err := target.StreamTo(stream, io.TeeReader(reader, &progress.Writer{})); err != nil {
+		return fmt.Errorf("updating %s: %w", logStr, err)
+	}
+	duration := time.Since(start)
+	transferred := progress.Reset()
+	fmt.Printf("\rTransferred %s (%s) at %.2f MiB/s (total: %v)\n",
+		logStr,
+		humanize.Bytes(transferred),
+		float64(transferred)/duration.Seconds()/1024/1024,
+		duration.Round(time.Second))
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.17
 require (
 	github.com/breml/rootcerts v0.2.0
 	github.com/donovanhide/eventsource v0.0.0-20210830082556-c59027999da0
-	github.com/gokrazy/gokrazy v0.0.0-20211218184743-3f026adfcbbc
-	github.com/gokrazy/internal v0.0.0-20211121154348-81842290f34c
+	github.com/gokrazy/gokrazy v0.0.0-20220111192931-e42cbd86b3f2
+	github.com/gokrazy/internal v0.0.0-20220113080712-36e28c66122e
 	github.com/gokrazy/updater v0.0.0-20211121155532-30ae8cd650ea
 	github.com/spf13/cobra v1.2.1
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
@@ -14,9 +14,6 @@ require (
 )
 
 require (
-	github.com/google/renameio/v2 v2.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/mdlayher/watchdog v0.0.0-20201005150459-8bdc4f41966b // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	rsc.io/goversion v1.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -79,13 +79,11 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/gokrazy/gokrazy v0.0.0-20211024151958-b718dd90ae71 h1:NHLkr4NYMY9gZGTI+jzIo38ZffMHkPbBzMcUDkyHs0g=
-github.com/gokrazy/gokrazy v0.0.0-20211024151958-b718dd90ae71/go.mod h1:eq2ROPhZJtxxEi21P8cbNqP8pwRBSpW/4LGKwNiQg2Y=
-github.com/gokrazy/gokrazy v0.0.0-20211218184743-3f026adfcbbc h1:yLkMmoDTsepW+vH1tL1QjtSv+DTZmIQ3zxTqye7Paw0=
-github.com/gokrazy/gokrazy v0.0.0-20211218184743-3f026adfcbbc/go.mod h1:JNNzNYJw3sUKc3lRtAeFv79YZI85Q3Og59BG1KBA1ss=
-github.com/gokrazy/internal v0.0.0-20210621162516-1b3b5687a06d/go.mod h1:Gqv1x1DNrObmBvVvblpZbvZizZ0dU5PwiwYHipmtY9Y=
-github.com/gokrazy/internal v0.0.0-20211121154348-81842290f34c h1:92mRiu1sN5FKQXn8xF44o0++mEmkwjr+EX1bVYgwGYs=
-github.com/gokrazy/internal v0.0.0-20211121154348-81842290f34c/go.mod h1:Gc9sU6yJ/qxg3gJZ1pjfcTAULa0swdTa4TH51g1e00E=
+github.com/gokrazy/gokrazy v0.0.0-20220111192931-e42cbd86b3f2 h1:8tFhu/kSaoxF6IGLkI5qtKIE2zaR1vqjTIFiAL+iGo4=
+github.com/gokrazy/gokrazy v0.0.0-20220111192931-e42cbd86b3f2/go.mod h1:z9nzDhiz6f52Zp21WSGnRzW2MlLBrsJdNLxXZoMti2w=
+github.com/gokrazy/internal v0.0.0-20220111191949-698f19a074ef/go.mod h1:Gc9sU6yJ/qxg3gJZ1pjfcTAULa0swdTa4TH51g1e00E=
+github.com/gokrazy/internal v0.0.0-20220113080712-36e28c66122e h1:L1StUIenFuTgn5tPTOrqjgbGY33pPXST1swQ1YzHJbY=
+github.com/gokrazy/internal v0.0.0-20220113080712-36e28c66122e/go.mod h1:Gc9sU6yJ/qxg3gJZ1pjfcTAULa0swdTa4TH51g1e00E=
 github.com/gokrazy/updater v0.0.0-20211121155532-30ae8cd650ea h1:NM/sLCKWWc9mnMtJZGbwOtaAwEpCEe6tlcXWKp3LEKk=
 github.com/gokrazy/updater v0.0.0-20211121155532-30ae8cd650ea/go.mod h1:PYOvzGOL4nlBmuxu7IyKQTFLaxr61+WPRNRzVtuYOHw=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -147,9 +145,7 @@ github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
-github.com/google/renameio v0.1.0 h1:GOZbcHa3HfsPKPlmyPyN2KEohoMXOhdMbHrvbpl2QaA=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/renameio/v2 v2.0.0 h1:UifI23ZTGY8Tt29JbYFiuyIU3eX+RNFtUwefq9qAhxg=
 github.com/google/renameio/v2 v2.0.0/go.mod h1:BtmJXm5YlszgC+TD4HOEEUFgkJP3nLxehU6hfe7jRt4=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -194,7 +190,6 @@ github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPK
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mdlayher/raw v0.0.0-20190303161257-764d452d77af/go.mod h1:rC/yE65s/DoHB6BzVOUBNYBGTg772JVytyAytffIZkY=
-github.com/mdlayher/watchdog v0.0.0-20201005150459-8bdc4f41966b h1:7tUBfsEEBWfFeHOB7CUfoOamak+Gx/BlirfXyPk1WjI=
 github.com/mdlayher/watchdog v0.0.0-20201005150459-8bdc4f41966b/go.mod h1:bmoJUS6qOA3uKFvF3KVuhf7mU1KQirzQMeHXtPyKEqg=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -594,7 +589,6 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
-rsc.io/goversion v1.2.0 h1:SPn+NLTiAG7w30IRK/DKp1BjvpWabYgxlLp/+kx5J8w=
 rsc.io/goversion v1.2.0/go.mod h1:Eih9y/uIBS3ulggl7KNJ09xGSLcuNaLgmvvqa07sgfo=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=


### PR DESCRIPTION
Related to https://github.com/gokrazy/gokrazy/issues/101 and https://github.com/gokrazy/gokrazy/pull/102

Some ARM devices (like Odroid XU4/HC1/HC2) only support MBR booting.
Allow generating MBR partition table for such devices.

gokr-packer now supports a TOML device manifest that can specify details
like MBR partition table, list of kernel files and any additional blobs
that need to be stored on disk.