### PR TITLE
packer: implement waitforclock per-package config files

### DIFF
--- a/cmd/gokr-packer/buildinit.go
+++ b/cmd/gokr-packer/buildinit.go
@@ -56,6 +56,8 @@ func main() {
 		)
 {{ if DontStart $.DontStart $path }}
 		svc := gokrazy.NewStoppedService(cmd)
+{{ else if WaitForClock $.WaitForClock $path }}
+		svc := gokrazy.NewDelayedService(cmd)
 {{ else }}
 		svc := gokrazy.NewService(cmd)
 {{ end }}
@@ -91,6 +93,10 @@ var initTmpl = template.Must(template.New("").Funcs(template.FuncMap{
 	"DontStart": func(dontStart map[string]bool, path string) bool {
 		return dontStart[filepath.Base(path)]
 	},
+
+	"WaitForClock": func(waitForClock map[string]bool, path string) bool {
+		return waitForClock[filepath.Base(path)]
+	},
 }).Parse(initTmplContents))
 
 func flattenFiles(prefix string, root *fileInfo) []string {
@@ -110,6 +116,7 @@ type gokrazyInit struct {
 	flagFileContents map[string]string
 	envFileContents  map[string]string
 	dontStart        map[string]bool
+	waitForClock     map[string]bool
 	buildTimestamp   string
 }
 
@@ -122,12 +129,14 @@ func (g *gokrazyInit) generate() ([]byte, error) {
 		Flags          map[string]string
 		Env            map[string]string
 		DontStart      map[string]bool
+		WaitForClock   map[string]bool
 	}{
 		Binaries:       flattenFiles("/", g.root),
 		BuildTimestamp: g.buildTimestamp,
 		Flags:          g.flagFileContents,
 		Env:            g.envFileContents,
 		DontStart:      g.dontStart,
+		WaitForClock:   g.waitForClock,
 	}); err != nil {
 		return nil, err
 	}

--- a/cmd/gokr-packer/buildinit.go
+++ b/cmd/gokr-packer/buildinit.go
@@ -57,7 +57,7 @@ func main() {
 {{ if DontStart $.DontStart $path }}
 		svc := gokrazy.NewStoppedService(cmd)
 {{ else if WaitForClock $.WaitForClock $path }}
-		svc := gokrazy.NewDelayedService(cmd)
+		svc := gokrazy.NewWaitForClockService(cmd)
 {{ else }}
 		svc := gokrazy.NewService(cmd)
 {{ end }}

--- a/cmd/gokr-packer/packer.go
+++ b/cmd/gokr-packer/packer.go
@@ -424,7 +424,7 @@ func findWaitForClock() (map[string]bool, error) {
 			continue
 		}
 		packageConfigFiles[pkg] = append(packageConfigFiles[pkg], packageConfigFile{
-			kind:         "wait for the clock before start",
+			kind:         "wait for clock synchronization before start",
 			path:         p.path,
 			lastModified: p.modTime,
 		})

--- a/cmd/gokr-packer/packer.go
+++ b/cmd/gokr-packer/packer.go
@@ -404,6 +404,39 @@ func findDontStart() (map[string]bool, error) {
 	return contents, nil
 }
 
+func findWaitForClock() (map[string]bool, error) {
+	waitForClockPaths, err := findPackageFiles("waitforclock")
+	if err != nil {
+		return nil, err
+	}
+
+	if len(waitForClockPaths) == 0 {
+		return nil, nil // no waitforclock.txt files found
+	}
+
+	buildPackages := buildPackagesFromFlags()
+
+	contents := make(map[string]bool)
+	for _, p := range waitForClockPaths {
+		pkg := strings.TrimSuffix(strings.TrimPrefix(p.path, "waitforclock/"), "/waitforclock.txt")
+		if !buildPackages[pkg] {
+			log.Printf("WARNING: waitforclock.txt file %s does not match any specified package (%s)", pkg, flag.Args())
+			continue
+		}
+		packageConfigFiles[pkg] = append(packageConfigFiles[pkg], packageConfigFile{
+			kind:         "wait for the clock before start",
+			path:         p.path,
+			lastModified: p.modTime,
+		})
+
+		// NOTE: ideally we would use the full package here, but our init
+		// template only deals with base names right now.
+		contents[filepath.Base(pkg)] = true
+	}
+
+	return contents, nil
+}
+
 type countingWriter int64
 
 func (cw *countingWriter) Write(p []byte) (n int, err error) {
@@ -714,6 +747,11 @@ func logic() error {
 		return err
 	}
 
+	waitForClock, err := findWaitForClock()
+	if err != nil {
+		return err
+	}
+
 	args := flag.Args()
 	fmt.Printf("Building %d Go packages:\n\n", len(args))
 	for _, pkg := range args {
@@ -757,6 +795,7 @@ func logic() error {
 			envFileContents:  envFileContents,
 			buildTimestamp:   buildTimestamp,
 			dontStart:        dontStart,
+			waitForClock:     waitForClock,
 		}
 		if *overwriteInit != "" {
 			return gokrazyInit.dump(*overwriteInit)

--- a/cmd/gokr-packer/packer.go
+++ b/cmd/gokr-packer/packer.go
@@ -387,7 +387,7 @@ func findDontStart() (map[string]bool, error) {
 	for _, p := range dontStartPaths {
 		pkg := strings.TrimSuffix(strings.TrimPrefix(p.path, "dontstart/"), "/dontstart.txt")
 		if !buildPackages[pkg] {
-			log.Printf("WARNING: environment variable file %s does not match any specified package (%s)", pkg, flag.Args())
+			log.Printf("WARNING: dontstart.txt file %s does not match any specified package (%s)", pkg, flag.Args())
 			continue
 		}
 		packageConfigFiles[pkg] = append(packageConfigFiles[pkg], packageConfigFile{

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/breml/rootcerts v0.2.0
 	github.com/donovanhide/eventsource v0.0.0-20210830082556-c59027999da0
-	github.com/gokrazy/gokrazy v0.0.0-20220111192931-e42cbd86b3f2
+	github.com/gokrazy/gokrazy v0.0.0-20220113081925-ca0fa4174944
 	github.com/gokrazy/internal v0.0.0-20220113080712-36e28c66122e
 	github.com/gokrazy/updater v0.0.0-20211121155532-30ae8cd650ea
 	github.com/spf13/cobra v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/gokrazy/gokrazy v0.0.0-20220111192931-e42cbd86b3f2 h1:8tFhu/kSaoxF6IGLkI5qtKIE2zaR1vqjTIFiAL+iGo4=
-github.com/gokrazy/gokrazy v0.0.0-20220111192931-e42cbd86b3f2/go.mod h1:z9nzDhiz6f52Zp21WSGnRzW2MlLBrsJdNLxXZoMti2w=
+github.com/gokrazy/gokrazy v0.0.0-20220113081925-ca0fa4174944 h1:aZgg4MvvoNdhEgfKxCNi3eCjvtfcJBS3GklxM09Ob4I=
+github.com/gokrazy/gokrazy v0.0.0-20220113081925-ca0fa4174944/go.mod h1:z9nzDhiz6f52Zp21WSGnRzW2MlLBrsJdNLxXZoMti2w=
 github.com/gokrazy/internal v0.0.0-20220111191949-698f19a074ef/go.mod h1:Gc9sU6yJ/qxg3gJZ1pjfcTAULa0swdTa4TH51g1e00E=
 github.com/gokrazy/internal v0.0.0-20220113080712-36e28c66122e h1:L1StUIenFuTgn5tPTOrqjgbGY33pPXST1swQ1YzHJbY=
 github.com/gokrazy/internal v0.0.0-20220113080712-36e28c66122e/go.mod h1:Gc9sU6yJ/qxg3gJZ1pjfcTAULa0swdTa4TH51g1e00E=


### PR DESCRIPTION
This PR adds a configuration `dontstart` it is related to https://github.com/gokrazy/gokrazy/pull/105.

This allows wait for the clock to be synced before starting the service

packer.go: adds `findWaitForClock()` function similar to `findDontStart()`
buildinit.go: adds an exclusive condition with don't start and start to run ~~`NewDelayedService()`~~ `NewWaitForClockService()`