### PR TITLE
packer: fail on small device

### DIFF
--- a/packer/packer.go
+++ b/packer/packer.go
@@ -412,6 +412,10 @@ func (p *Pack) writeGPT(w io.Writer, devsize uint64, primary bool) error {
 }
 
 func (p *Pack) Partition(o *os.File, devsize uint64) error {
+	minsize := uint64(1100 * MB)
+	if devsize < minsize {
+		return fmt.Errorf("device is too small (at least %d MB needed, %d MB available)", minsize/MB, devsize/MB)
+	}
 	if !p.UseGPT {
 		return writeMBRPartitionTable(o, devsize)
 	}


### PR DESCRIPTION
I (stupidly) tried to run packer on a SD card of 512MB. Everything looked fine, but nothing worked...

This PR adds a check that the device has enough capacity and fails otherwise:
```
device is too small (1100 MB needed, 488 MB available)
```

The check is not overly accurate (it actually needs a couple bytes more), but I think it will cover the vast majority of usecases.