### PR TITLE
Use shared helper to build http client for log and run

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/breml/rootcerts v0.2.0
 	github.com/donovanhide/eventsource v0.0.0-20210830082556-c59027999da0
 	github.com/gokrazy/gokrazy v0.0.0-20220113081925-ca0fa4174944
-	github.com/gokrazy/internal v0.0.0-20220709172510-3a50f98beeea
+	github.com/gokrazy/internal v0.0.0-20220913201530-a2f6689ea8f8
 	github.com/gokrazy/updater v0.0.0-20211121155532-30ae8cd650ea
 	github.com/spf13/cobra v1.5.0
 	golang.org/x/mod v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/donovanhide/eventsource v0.0.0-20210830082556-c59027999da0/go.mod h1:
 github.com/gokrazy/gokrazy v0.0.0-20220113081925-ca0fa4174944 h1:aZgg4MvvoNdhEgfKxCNi3eCjvtfcJBS3GklxM09Ob4I=
 github.com/gokrazy/gokrazy v0.0.0-20220113081925-ca0fa4174944/go.mod h1:z9nzDhiz6f52Zp21WSGnRzW2MlLBrsJdNLxXZoMti2w=
 github.com/gokrazy/internal v0.0.0-20220111191949-698f19a074ef/go.mod h1:Gc9sU6yJ/qxg3gJZ1pjfcTAULa0swdTa4TH51g1e00E=
-github.com/gokrazy/internal v0.0.0-20220709172510-3a50f98beeea h1:zj2YbSnHCoADuvEUJOPXNVexuZsNd6y/oQBs0vBJIuU=
-github.com/gokrazy/internal v0.0.0-20220709172510-3a50f98beeea/go.mod h1:Gc9sU6yJ/qxg3gJZ1pjfcTAULa0swdTa4TH51g1e00E=
+github.com/gokrazy/internal v0.0.0-20220913201530-a2f6689ea8f8 h1:XyoKwLC5MRSJAUGHgkPe6hrjfVFHaeYujIXRNKTwagc=
+github.com/gokrazy/internal v0.0.0-20220913201530-a2f6689ea8f8/go.mod h1:oQlf9/bGlGch8QyOWTZlupgBKjzdLcBhi6SF9m9V8DM=
 github.com/gokrazy/updater v0.0.0-20211121155532-30ae8cd650ea h1:NM/sLCKWWc9mnMtJZGbwOtaAwEpCEe6tlcXWKp3LEKk=
 github.com/gokrazy/updater v0.0.0-20211121155532-30ae8cd650ea/go.mod h1:PYOvzGOL4nlBmuxu7IyKQTFLaxr61+WPRNRzVtuYOHw=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=


### PR DESCRIPTION
Also this fixes `gok run` building anything at all.

Looking at `packer.Build` in its current version, it just isn't suited to "build current directory" it seems. Or at least I could not find any way to get it to build local packages (such as `.` or `./package`) no matter what I tried to pass to it from the `gok run` code. (I fully expect this to not just get merged as I put it, but rather invite a discussion on the correct way to fix `gok run`)