### PR TITLE
Pass fs-size to mkfs.ext4 so it doesn't scribble over secondary GPT

### DIFF
--- a/cmd/gokr-packer/packer.go
+++ b/cmd/gokr-packer/packer.go
@@ -816,7 +816,7 @@ func (p *pack) overwriteFile(filename string, root *fileInfo, rootDeviceFiles []
 	}
 
 	fmt.Printf("If your applications need to store persistent data, create a file system using e.g.:\n")
-	fmt.Printf("\t/sbin/mkfs.ext4 %s -F -E offset=%v\n", *overwrite, 8192*512+1100*MB)
+	fmt.Printf("\t/sbin/mkfs.ext4 -F -E offset=%v %s %v\n", 8192*512+1100*MB, *overwrite, packer.PermSizeInKB(uint64(*targetStorageBytes)))
 	fmt.Printf("\n")
 
 	return int64(bs), int64(rs), f.Close()

--- a/packer/packer.go
+++ b/packer/packer.go
@@ -101,6 +101,10 @@ func permSize(devsize uint64) uint32 {
 	return permSize
 }
 
+func PermSizeInKB(devsize uint64) uint32 {
+	return permSize(devsize) / 2
+}
+
 // writePartitionTable writes a Hybrid MBR: it contains the GPT protective
 // partition so that the Linux kernel recognizes the disk as GPT, but it also
 // contains the FAT32 partition so that the Raspberry Pi bootloader still works.

--- a/packer/packer.go
+++ b/packer/packer.go
@@ -102,7 +102,9 @@ func permSize(devsize uint64) uint32 {
 }
 
 func PermSizeInKB(devsize uint64) uint32 {
-	return permSize(devsize) / 2
+	permSizeLBA := permSize(devsize)
+	permSizeBytes := permSizeLBA * 512
+	return permSizeBytes / 1024
 }
 
 // writePartitionTable writes a Hybrid MBR: it contains the GPT protective


### PR DESCRIPTION
When creating a disk image, `gokr-packer` shows an `mkfs.ext4` command to create the filesystem for `/perm`

```ShellSession
$ gokr-packer -overwrite gokrazy.img -target_storage_bytes 1258299392 github.com/gokrazy/hello
...
If your applications need to store persistent data, create a file system using e.g.:
	/sbin/mkfs.ext4 gokrazy.img -F -E offset=1157627904
```

This will overwrite the secondary GPT at the end of the disk image.  

```ShellSession
$ /opt/homebrew/opt/e2fsprogs/sbin/mkfs.ext4 -F -E offset=1157627904 gokrazy.img
...
Writing superblocks and filesystem accounting information: done
```

```ShellSession
$ /opt/homebrew/opt/util-linux/sbin/fdisk -l gokrazy.img 
The backup GPT table is corrupt, but the primary appears OK, so that will be used.
...
```