### PR TITLE
parttable: pass HOME env var to sudo

### DIFF
--- a/internal/packer/parttable.go
+++ b/internal/packer/parttable.go
@@ -64,7 +64,10 @@ func (p *Pack) SudoPartition(path string) (*os.File, error) {
 	cmd := exec.Command("sudo", append([]string{"--preserve-env"}, os.Args...)...)
 	// We cannot use cmd.ExtraFiles with sudo, as sudo closes all file
 	// descriptors but stdin, stdout and stderr.
-	cmd.Env = []string{"GOKR_PACKER_FD=1"}
+	cmd.Env = []string{
+		"GOKR_PACKER_FD=1",
+		fmt.Sprintf("HOME=%s", os.Getenv("HOME")), // for instance config detection
+	}
 	cmd.Stdout = os.NewFile(uintptr(pair[1]), "")
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {


### PR DESCRIPTION
From the commit message:

```
Without passing $HOME into the `sudo` invocation the instance parent directory detection
(https://github.com/gokrazy/internal/blob/main/instanceflag/instanceflag.go#L19) fails:

  $ gok -i test overwrite --full /dev/sdc
  [..]
  2023/01/25 22:13:04 partitioning /dev/sdc (GPT + Hybrid MBR)
  2023/01/25 22:13:04 Using sudo to gain permission to format /dev/sdc
  2023/01/25 22:13:04 If you prefer, cancel and use: sudo setfacl -m u:${USER}:rw /dev/sdc
  2023/01/25 22:13:04 open os.UserHomeDir failed: $HOME is not defined/gokrazy/test/config.json: no such file or directory
  2023/01/25 22:13:04 exit status 1

This commit does the necessary passing.
```

While the attached commit fixes the immediate issue I'm not sure it's the right fix, so please do make suggestions if you have any.

(I wondered if we should be Completely Honest (tm) and only set $HOME if it's set in the parent's environment (using `os.LookupEnv` first) but that seems a) unnecessarily complicated and b) at any rate `os.UserHomeDir()` considers both a missing $HOME and one with an empty value as both signifying no home directory found.)

Also, something seems broken (or I don't understand it!) in `instanceflag.parentDir`:

```go
homeDir, err := os.UserHomeDir()
if err != nil {
		homeDir = fmt.Sprintf("os.UserHomeDir failed: %v", err)
}
def = filepath.Join(homeDir, "gokrazy")
```

it's not clear to my why you'd want to treat the error as a path component. I'd guess the intended behaviour here is to either abort (panic?) if the home dir can't be determined, or maybe use the current working directory as parent directory? Ultimately the configuration location has be inferred somehow, if not passed explicitly, so I suppose failing if the home directory isn't found is fair.