### PR TITLE
gok overwrite: add gaf (gokrazy archive format) output

### DIFF
--- a/internal/gok/overwrite.go
+++ b/internal/gok/overwrite.go
@@ -102,7 +102,11 @@ func (r *overwriteImplConfig) run(ctx context.Context, args []string, stdout, st
 		return err
 	}
 
-	packer.Main(cfg, "gokrazy gok")
+	pack := &packer.Pack{
+		Cfg:    cfg,
+	}
+
+	pack.Main("gokrazy gok")
 
 	return nil
 }

--- a/internal/gok/sbom.go
+++ b/internal/gok/sbom.go
@@ -2,21 +2,14 @@ package gok
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"os"
-	"path/filepath"
-	"sort"
-	"strings"
 
-	"github.com/gokrazy/internal/config"
 	"github.com/gokrazy/internal/instanceflag"
 	"github.com/gokrazy/internal/updateflag"
-	internalpacker "github.com/gokrazy/tools/internal/packer"
-	"github.com/gokrazy/tools/packer"
+	"github.com/gokrazy/tools/internal/packer"
 	"github.com/spf13/cobra"
 )
 
@@ -52,152 +45,21 @@ func init() {
 }
 
 func (r *sbomConfig) run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
-	cfg, err := config.ReadFromFile()
-	if err != nil {
-		if os.IsNotExist(err) {
-			// best-effort compatibility for old setups
-			cfg = config.NewStruct(instanceflag.Instance())
-		} else {
-			return err
-		}
-	}
-
-	if err := os.Chdir(config.InstancePath()); err != nil {
-		return err
-	}
 
 	updateflag.SetUpdate("yes")
 
-	type fileHash struct {
-		// Path is relative to the gokrazy instance directory (or absolute).
-		Path string `json:"path"`
-
-		// Hash is the SHA256 sum of the file.
-		Hash string `json:"hash"`
-	}
-
-	type sbom struct {
-		// ConfigHash is the SHA256 sum of the gokrazy instance config (loaded
-		// from config.json).
-		ConfigHash fileHash `json:"config_hash"`
-
-		// GoModHashes is list of fileHashes, sorted by path.
-		//
-		// It contains one entry for each go.mod file that was used to build a
-		// gokrazy instance.
-		GoModHashes []fileHash `json:"go_mod_hashes"`
-
-		// ExtraFileHashes is list of fileHashes, sorted by path.
-		//
-		// It contains one entry for each file referenced via ExtraFilePaths:
-		// https://gokrazy.org/userguide/instance-config/#packageextrafilepaths
-		ExtraFileHashes []fileHash `json:"extra_file_hashes"`
-	}
-
-	formattedCfg, err := cfg.FormatForFile()
-	if err != nil {
+	sbomMarshaled, sbomWithHash, err := packer.GenerateSBOM()
+	if os.IsNotExist(err) {
+		// Common case, handle with a good error message
+		os.Stderr.WriteString("\n")
+		log.Print(err)
+		return nil
+	} else if err != nil {
 		return err
 	}
 
-	result := sbom{
-		ConfigHash: fileHash{
-			Path: config.InstanceConfigPath(),
-			Hash: fmt.Sprintf("%x", sha256.Sum256([]byte(formattedCfg))),
-		},
-	}
-
-	extraFiles, err := internalpacker.FindExtraFiles(cfg)
-	if err != nil {
-		return err
-	}
-
-	packages := append(getGokrazySystemPackages(cfg), cfg.Packages...)
-
-	for _, pkgAndVersion := range packages {
-		pkg := pkgAndVersion
-		if idx := strings.IndexByte(pkg, '@'); idx > -1 {
-			pkg = pkg[:idx]
-		}
-		buildDir := packer.BuildDir(pkg)
-		_, err := os.Stat(buildDir)
-		if os.IsNotExist(err) {
-			// Common case, handle with a good error message
-			wd, _ := os.Getwd()
-			os.Stderr.WriteString("\n")
-			log.Printf("Error: build directory %q does not exist in %q", buildDir, wd)
-			log.Printf("Try 'gok -i %s add %s' followed by an update.", instanceflag.Instance(), pkg)
-			log.Printf("Afterwards, your 'gok sbom' command should work")
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-
-		path := filepath.Join(buildDir, "go.mod")
-		b, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		result.GoModHashes = append(result.GoModHashes, fileHash{
-			Path: path,
-			Hash: fmt.Sprintf("%x", sha256.Sum256(b)),
-		})
-
-		files := append([]*internalpacker.FileInfo{}, extraFiles[pkg]...)
-		for len(files) > 0 {
-			fi := files[0]
-			files = files[1:]
-			files = append(files, fi.Dirents...)
-			if fi.FromHost == "" {
-				// Files that are not copied from the host are contained
-				// fully in the config, which we already hashed.
-				continue
-			}
-
-			path := fi.FromHost
-			b, err := os.ReadFile(path)
-			if err != nil {
-				return err
-			}
-			result.ExtraFileHashes = append(result.ExtraFileHashes, fileHash{
-				Path: path,
-				Hash: fmt.Sprintf("%x", sha256.Sum256(b)),
-			})
-		}
-	}
-
-	sort.Slice(result.GoModHashes, func(i, j int) bool {
-		a := result.GoModHashes[i]
-		b := result.GoModHashes[j]
-		return a.Path < b.Path
-	})
-
-	sort.Slice(result.ExtraFileHashes, func(i, j int) bool {
-		a := result.ExtraFileHashes[i]
-		b := result.ExtraFileHashes[j]
-		return a.Path < b.Path
-	})
-
-	b, err := json.MarshalIndent(result, "", "    ")
-	if err != nil {
-		return err
-	}
-	b = append(b, '\n')
-
-	sbomWithHash := struct {
-		SBOMHash string `json:"sbom_hash"`
-		SBOM     sbom   `json:"sbom"`
-	}{
-		SBOMHash: fmt.Sprintf("%x", sha256.Sum256(b)),
-		SBOM:     result,
-	}
-	b, err = json.MarshalIndent(sbomWithHash, "", "    ")
-	if err != nil {
-		return err
-	}
-	b = append(b, '\n')
 	if r.format == "json" {
-		stdout.Write(b)
+		stdout.Write(sbomMarshaled)
 	} else if r.format == "hash" {
 		fmt.Fprintf(stdout, "%s\n", sbomWithHash.SBOMHash)
 	} else {

--- a/internal/gok/update.go
+++ b/internal/gok/update.go
@@ -76,7 +76,11 @@ func (r *updateImplConfig) run(ctx context.Context, args []string, stdout, stder
 		return err
 	}
 
-	packer.Main(cfg, "gokrazy gok")
+	pack := &packer.Pack{
+		Cfg: cfg,
+	}
+
+	pack.Main("gokrazy gok")
 
 	return nil
 }

--- a/internal/oldpacker/oldpacker.go
+++ b/internal/oldpacker/oldpacker.go
@@ -224,7 +224,11 @@ func logic(instanceDir string) error {
 		return nil
 	}
 
-	internalpacker.Main(&cfg, "gokrazy packer")
+	pack := &internalpacker.Pack{
+		Cfg: &cfg,
+	}
+
+	pack.Main("gokrazy packer")
 	return nil
 }
 

--- a/internal/packer/gaf.go
+++ b/internal/packer/gaf.go
@@ -1,0 +1,128 @@
+package packer
+
+import (
+	"archive/zip"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// overwriteGaf writes a gaf (gokrazy archive format) file
+// by packing build artifacts and
+// storing them into a newly created, uncompressed zip.
+func (p *Pack) overwriteGaf(root *FileInfo) error {
+	dir, err := os.MkdirTemp("", "gokrazy")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(dir)
+
+	tmpMBR, err := os.Create(filepath.Join(dir, "mbr.img"))
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmpMBR.Name())
+
+	tmpBoot, err := os.Create(filepath.Join(dir, "boot.img"))
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmpBoot.Name())
+
+	tmpRoot, err := os.Create(filepath.Join(dir, "root.img"))
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmpRoot.Name())
+
+	tmpSBOM, err := os.Create(filepath.Join(dir, "sbom.json"))
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmpSBOM.Name())
+
+	if err := p.writeBoot(tmpBoot, tmpMBR.Name()); err != nil {
+		return err
+	}
+
+	if err := writeRoot(tmpRoot, root); err != nil {
+		return err
+	}
+
+	sbomMarshaled, _, err := GenerateSBOM()
+	if err != nil {
+		return err
+	}
+
+	if _, err := tmpSBOM.Write(sbomMarshaled); err != nil {
+		return err
+	}
+
+	tmpMBR.Close()
+	tmpBoot.Close()
+	tmpRoot.Close()
+	tmpSBOM.Close()
+
+	if err := writeGafArchive(dir, p.Output.Path); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// writeGafArchive archives build artifacts into
+// a gaf (gokrazy archive format) file
+// by reading artifacts from a source directory
+// and storing them into a newly created, uncompressed zip.
+func writeGafArchive(sourceDir, targetFile string) error {
+	f, err := os.Create(targetFile)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	writer := zip.NewWriter(f)
+	defer writer.Close()
+
+	return filepath.Walk(sourceDir, func(filePath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Ignore directories in the sourceDir.
+		if info.IsDir() {
+			return nil
+		}
+
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return err
+		}
+
+		// Don't compress, just "Store" (archive),
+		// to allow direct file access and cheap unarchive.
+		header.Method = zip.Store
+
+		header.Name, err = filepath.Rel(sourceDir, filePath)
+		if err != nil {
+			return err
+		}
+
+		headerWriter, err := writer.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+
+		sf, err := os.Open(filePath)
+		if err != nil {
+			return err
+		}
+		defer sf.Close()
+
+		if _, err := io.Copy(headerWriter, sf); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}

--- a/internal/packer/sbom.go
+++ b/internal/packer/sbom.go
@@ -1,0 +1,174 @@
+package packer
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/gokrazy/internal/config"
+	"github.com/gokrazy/internal/instanceflag"
+	"github.com/gokrazy/tools/packer"
+)
+
+type FileHash struct {
+	// Path is relative to the gokrazy instance directory (or absolute).
+	Path string `json:"path"`
+
+	// Hash is the SHA256 sum of the file.
+	Hash string `json:"hash"`
+}
+
+type SBOM struct {
+	// ConfigHash is the SHA256 sum of the gokrazy instance config (loaded
+	// from config.json).
+	ConfigHash FileHash `json:"config_hash"`
+
+	// GoModHashes is list of FileHashes, sorted by path.
+	//
+	// It contains one entry for each go.mod file that was used to build a
+	// gokrazy instance.
+	GoModHashes []FileHash `json:"go_mod_hashes"`
+
+	// ExtraFileHashes is list of FileHashes, sorted by path.
+	//
+	// It contains one entry for each file referenced via ExtraFilePaths:
+	// https://gokrazy.org/userguide/instance-config/#packageextrafilepaths
+	ExtraFileHashes []FileHash `json:"extra_file_hashes"`
+}
+
+type SBOMWithHash struct {
+	SBOMHash string `json:"sbom_hash"`
+	SBOM     SBOM   `json:"sbom"`
+}
+
+// GenerateSBOM generates a Software Bills Of Material (SBOM) for the
+// local gokrazy instance.
+func GenerateSBOM() ([]byte, SBOMWithHash, error) {
+	cfg, err := config.ReadFromFile()
+	if err != nil {
+		if os.IsNotExist(err) {
+			// best-effort compatibility for old setups
+			cfg = config.NewStruct(instanceflag.Instance())
+		} else {
+			return nil, SBOMWithHash{}, err
+		}
+	}
+
+	if err := os.Chdir(config.InstancePath()); err != nil {
+		return nil, SBOMWithHash{}, err
+	}
+
+	formattedCfg, err := cfg.FormatForFile()
+	if err != nil {
+		return nil, SBOMWithHash{}, err
+	}
+
+	result := SBOM{
+		ConfigHash: FileHash{
+			Path: config.InstanceConfigPath(),
+			Hash: fmt.Sprintf("%x", sha256.Sum256([]byte(formattedCfg))),
+		},
+	}
+
+	extraFiles, err := FindExtraFiles(cfg)
+	if err != nil {
+		return nil, SBOMWithHash{}, err
+	}
+
+	packages := append(getGokrazySystemPackages(cfg), cfg.Packages...)
+
+	for _, pkgAndVersion := range packages {
+		pkg := pkgAndVersion
+		if idx := strings.IndexByte(pkg, '@'); idx > -1 {
+			pkg = pkg[:idx]
+		}
+		buildDir := packer.BuildDir(pkg)
+		if _, err := os.Stat(buildDir); err != nil {
+			wd, _ := os.Getwd()
+			errStr := fmt.Sprintf("Error: build directory %q does not exist in %q\n", buildDir, wd)
+			errStr += fmt.Sprintf("Try 'gok -i %s add %s' followed by an update.\n", instanceflag.Instance(), pkg)
+			errStr += fmt.Sprintf("Afterwards, your 'gok sbom' command should work")
+			return nil, SBOMWithHash{}, fmt.Errorf("%s: %w", errStr, err)
+		}
+
+		path := filepath.Join(buildDir, "go.mod")
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return nil, SBOMWithHash{}, err
+		}
+		result.GoModHashes = append(result.GoModHashes, FileHash{
+			Path: path,
+			Hash: fmt.Sprintf("%x", sha256.Sum256(b)),
+		})
+
+		files := append([]*FileInfo{}, extraFiles[pkg]...)
+		for len(files) > 0 {
+			fi := files[0]
+			files = files[1:]
+			files = append(files, fi.Dirents...)
+			if fi.FromHost == "" {
+				// Files that are not copied from the host are contained
+				// fully in the config, which we already hashed.
+				continue
+			}
+
+			path := fi.FromHost
+			b, err := os.ReadFile(path)
+			if err != nil {
+				return nil, SBOMWithHash{}, err
+			}
+			result.ExtraFileHashes = append(result.ExtraFileHashes, FileHash{
+				Path: path,
+				Hash: fmt.Sprintf("%x", sha256.Sum256(b)),
+			})
+		}
+	}
+
+	sort.Slice(result.GoModHashes, func(i, j int) bool {
+		a := result.GoModHashes[i]
+		b := result.GoModHashes[j]
+		return a.Path < b.Path
+	})
+
+	sort.Slice(result.ExtraFileHashes, func(i, j int) bool {
+		a := result.ExtraFileHashes[i]
+		b := result.ExtraFileHashes[j]
+		return a.Path < b.Path
+	})
+
+	b, err := json.MarshalIndent(result, "", "    ")
+	if err != nil {
+		return nil, SBOMWithHash{}, err
+	}
+	b = append(b, '\n')
+
+	sH := SBOMWithHash{
+		SBOMHash: fmt.Sprintf("%x", sha256.Sum256(b)),
+		SBOM:     result,
+	}
+
+	sM, err := json.MarshalIndent(sH, "", "    ")
+	if err != nil {
+		return nil, SBOMWithHash{}, err
+	}
+	sM = append(sM, '\n')
+
+	return sM, sH, nil
+}
+
+func getGokrazySystemPackages(cfg *config.Struct) []string {
+	pkgs := append([]string{}, cfg.GokrazyPackagesOrDefault()...)
+	pkgs = append(pkgs, packer.InitDeps(cfg.InternalCompatibilityFlags.InitPkg)...)
+	pkgs = append(pkgs, cfg.KernelPackageOrDefault())
+	if fw := cfg.FirmwarePackageOrDefault(); fw != "" {
+		pkgs = append(pkgs, fw)
+	}
+	if e := cfg.EEPROMPackageOrDefault(); e != "" {
+		pkgs = append(pkgs, e)
+	}
+	return pkgs
+}


### PR DESCRIPTION
It adds support within gok overwrite for the `gaf` output format.
`gaf` is the new gokrazy archive format output type.
It is immagined for storage and upgrade purposes.
A single, uncompressed zip archive file that contains:
- the MBR image (mbr.img)
- the boot image (boot.img)
- the root image (root.img)
- the SBOM of the gokrazy build (sbom.json)

It is lighter in size than a "full" disk image (it doesn't have the
partition filling bits).
It contains all the necessary bits to upgrade a gokrazy instance (all it
takes is the 3 imgs).
It can be directly accessed for a single file extraction (non compressed
zip property).
It can be easily unarchived by gokrazy appliances (cheap unzipping).
It is easy to verify what the build contains (SBOM alongside to be read).

Users can now generate a gaf output by issuing
```
gok overwrite --gaf gokrazy-build.gaf
```