### PR TITLE
fix: prevent race condition in PackageDirs

### DIFF
--- a/packer/gotool.go
+++ b/packer/gotool.go
@@ -413,22 +413,21 @@ func PackageDir(pkg string) (string, error) {
 	return strings.TrimSpace(string(b)), nil
 }
 
+// PackageDirs returns the package directories, in the same order as the argument
 func PackageDirs(pkgs []string) ([]string, error) {
-	var (
-		eg     errgroup.Group
-		dirsMu sync.Mutex
-		dirs   []string
-	)
-	for _, pkg := range pkgs {
+	var eg errgroup.Group
+
+	// pre-allocate the slice for concurrent writes
+	dirs := make([]string, len(pkgs))
+	for i, pkg := range pkgs {
+		i := i     // copy
 		pkg := pkg // copy
 		eg.Go(func() error {
 			dir, err := PackageDir(pkg)
 			if err != nil {
 				return err
 			}
-			dirsMu.Lock()
-			defer dirsMu.Unlock()
-			dirs = append(dirs, dir)
+			dirs[i] = dir
 			return nil
 		})
 	}


### PR DESCRIPTION
I saw the following log, where the package and extrafiles are mixed up:
```
Including extra files for Go packages:

  github.com/oliverpool/grafana-armv6
    will include extra files in the root file system
      from extrafiles/github.com/oliverpool/grafana-armv6
      last modified: 2023-03-01T22:25:30+01:00 (454h57m51s ago)

  tailscale.com/cmd/tailscaled
    will include extra files in the root file system
      from /home/olivier/go/pkg/mod/github.com/oliverpool/grafana-armv6@v1.0.3-v8.5.21/_gokrazy/extrafiles
      last modified: 2023-03-01T21:14:00+01:00 (456h9m20s ago)
```

This sounded like a concurrency issue, and sure enough the `packer.PackageDirs` function does not return the dirs in the same order as the argument, as expected by (note the `idx`):
https://github.com/gokrazy/tools/blob/69473ec010f406f8125665ff28f2bd6490f9bfcb/internal/packer/packer.go#L579-L595

This PR fixes this.