### PR TITLE
gok: improve the error message for wrong target arch

### DIFF
--- a/internal/packer/packer.go
+++ b/internal/packer/packer.go
@@ -1834,7 +1834,7 @@ func (pack *Pack) validateTargetArchMatchesKernel() error {
 	}
 	targetArch := packer.TargetArch()
 	if kernelArch != targetArch {
-		return fmt.Errorf("target architecture %q doesn't match the %s kernel type %q",
+		return fmt.Errorf("target architecture %q (GOARCH) doesn't match the %s kernel type %q",
 			targetArch,
 			cfg.KernelPackageOrDefault(),
 			kernelArch)


### PR DESCRIPTION
An issue has been reported regarding the wrong target arch, by @brutella : https://github.com/gokrazy-community/kernel-rpi-os-32/issues/4

```
target architecture "arm64" doesn't match the github.com/gokrazy-community/kernel-rpi-os-32/dist kernel type "arm"
```

Adding `GOARCH=arm` fixed the issue.

This PR adds a hint to the error message, to look for GOARCH:

```
target architecture "arm64" (GOARCH) doesn't match the github.com/gokrazy-community/kernel-rpi-os-32/dist kernel type "arm"
```

Introduced by https://github.com/gokrazy/gokrazy/issues/191 and https://github.com/gokrazy/tools/pull/54