### PR TITLE
Fix SBOM generation inconsistency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/breml/rootcerts v0.2.10
 	github.com/donovanhide/eventsource v0.0.0-20210830082556-c59027999da0
-	github.com/gokrazy/internal v0.0.0-20230313074923-5f469e7488b0
+	github.com/gokrazy/internal v0.0.0-20231010202000-a93c67aeb340
 	github.com/gokrazy/updater v0.0.0-20230215172637-813ccc7f21e2
 	github.com/google/go-cmp v0.5.9
 	github.com/google/renameio/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,12 @@
 github.com/breml/rootcerts v0.2.10 h1:UGVZ193UTSUASpGtg6pbDwzOd7XQP+at0Ssg1/2E4h8=
 github.com/breml/rootcerts v0.2.10/go.mod h1:24FDtzYMpqIeYC7QzaE8VPRQaFZU5TIUDlyk8qwjD88=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/damdo/internal v0.0.0-20231010185710-329afa6a2d6e h1:8gKsjwVk9zS/SYhK0f5wmGE6Mm1fTd3Xo17JPSNYC+0=
+github.com/damdo/internal v0.0.0-20231010185710-329afa6a2d6e/go.mod h1:CIE3ta1pA9UGyV1BM6wSc9BvNIZTm6keFCy/ifi6PCw=
 github.com/donovanhide/eventsource v0.0.0-20210830082556-c59027999da0 h1:C7t6eeMaEQVy6e8CarIhscYQlNmw5e3G36y7l7Y21Ao=
 github.com/donovanhide/eventsource v0.0.0-20210830082556-c59027999da0/go.mod h1:56wL82FO0bfMU5RvfXoIwSOP2ggqqxT+tAfNEIyxuHw=
-github.com/gokrazy/internal v0.0.0-20230313074923-5f469e7488b0 h1:2Hh4S4t7xR3vNqjpVOWc9UeMdx09y04pviuiL9vfzI8=
-github.com/gokrazy/internal v0.0.0-20230313074923-5f469e7488b0/go.mod h1:CIE3ta1pA9UGyV1BM6wSc9BvNIZTm6keFCy/ifi6PCw=
+github.com/gokrazy/internal v0.0.0-20231010202000-a93c67aeb340 h1:ddYQ2L0WsOFaD28ex00IgDP9r3oRlDVyprwaUk2BGYo=
+github.com/gokrazy/internal v0.0.0-20231010202000-a93c67aeb340/go.mod h1:CIE3ta1pA9UGyV1BM6wSc9BvNIZTm6keFCy/ifi6PCw=
 github.com/gokrazy/updater v0.0.0-20230215172637-813ccc7f21e2 h1:kBY5R1tSf+EYZ+QaSrofLaVJtBqYsVNVBWkdMq3Smcg=
 github.com/gokrazy/updater v0.0.0-20230215172637-813ccc7f21e2/go.mod h1:PYOvzGOL4nlBmuxu7IyKQTFLaxr61+WPRNRzVtuYOHw=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=

--- a/internal/packer/packer.go
+++ b/internal/packer/packer.go
@@ -1005,10 +1005,6 @@ func (pack *Pack) logic(programName string) error {
 		return fmt.Errorf("both -update and -overwrite are specified; use either one, not both")
 	}
 
-	if cfg.InternalCompatibilityFlags.Sudo == "" {
-		cfg.InternalCompatibilityFlags.Sudo = "auto"
-	}
-
 	var mbrOnlyWithoutGpt bool
 	var rootDeviceFiles []deviceconfig.RootFile
 	if cfg.DeviceType != "" {

--- a/internal/packer/parttable.go
+++ b/internal/packer/parttable.go
@@ -115,13 +115,13 @@ func (p *Pack) SudoPartition(path string) (*os.File, error) {
 }
 
 func (p *Pack) partition(path string) (*os.File, error) {
-	if p.Cfg.InternalCompatibilityFlags.Sudo == "always" {
+	if p.Cfg.InternalCompatibilityFlags.SudoOrDefault() == "always" {
 		return p.SudoPartition(path)
 	}
 	o, err := os.Create(path)
 	if err != nil {
 		pe, ok := err.(*os.PathError)
-		if ok && pe.Err == syscall.EACCES && p.Cfg.InternalCompatibilityFlags.Sudo == "auto" {
+		if ok && pe.Err == syscall.EACCES && p.Cfg.InternalCompatibilityFlags.SudoOrDefault() == "auto" {
 			// permission denied
 			log.Printf("Using sudo to gain permission to format %s", path)
 			log.Printf("If you prefer, cancel and use: sudo setfacl -m u:${USER}:rw %s", path)

--- a/internal/packer/sbom.go
+++ b/internal/packer/sbom.go
@@ -72,7 +72,7 @@ func GenerateSBOM(cfg *config.Struct) ([]byte, SBOMWithHash, error) {
 	result := SBOM{
 		ConfigHash: FileHash{
 			Path: config.InstanceConfigPath(),
-			Hash: fmt.Sprintf("%x", sha256.Sum256([]byte(formattedCfg))),
+			Hash: fmt.Sprintf("%x", sha256.Sum256([]byte(string(formattedCfg)))),
 		},
 	}
 


### PR DESCRIPTION
Currently SBOMs may have inconsistent hashing of the configuration file.

The representation of the config file in fact may differ at certain stages of the gok commands lifecycle, where at packer running time for example, extra InternalCompatibilityFlags would be added in memory (while that not being the case at `gok sbom` time), resulting in a differing config and as such differing SBOM hashes. The same would happen due to the differing pointer addresses in the config that resulted in differing hashing results.

This is now fixed by removing the InternalCompatibilityFlags from the config prior to its hashing, as well as converting the config into a string before performing the hash computation, to avoid hashing pointers problems.