### PR TITLE
Add ability to have sub-path globs and include overlays

### DIFF
--- a/internal/packer/write.go
+++ b/internal/packer/write.go
@@ -203,7 +203,6 @@ func (p *Pack) writeBoot(f io.Writer, mbrfilename string) error {
 			return err
 		}
 	}
-
 	var eepromDir string
 	if eeprom := p.Cfg.EEPROMPackageOrDefault(); eeprom != "" {
 		var err error

--- a/internal/packer/write.go
+++ b/internal/packer/write.go
@@ -212,7 +212,6 @@ func (p *Pack) writeBoot(f io.Writer, mbrfilename string) error {
 			return err
 		}
 	}
-
 	kernelDir, err := packer.PackageDir(p.Cfg.KernelPackageOrDefault())
 	if err != nil {
 		return err


### PR DESCRIPTION
This achieves two things:
- It refactors the glob copy function such that it can actually handle sub-directories correctly (by copying using relative paths as opposed to always stripping the entire path away)
- It adds `overlays/*.dtbo` to the globs to copy overlays from the kernel package (if present)

Future things this PR is not meant to address (but will be useful in the future imo):
- Configuration to include overlays using the stock kernel package
- Configuration to adjust `config.txt` to add `dtoverlay` lines