### PR TITLE
Fix SBOM generation inconsistency, take 2

### DIFF
--- a/internal/gok/overwrite.go
+++ b/internal/gok/overwrite.go
@@ -65,6 +65,11 @@ func init() {
 }
 
 func (r *overwriteImplConfig) run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+	fileCfg, err := config.ReadFromFile()
+	if err != nil {
+		return err
+	}
+
 	cfg, err := config.ReadFromFile()
 	if err != nil {
 		return err
@@ -121,8 +126,9 @@ func (r *overwriteImplConfig) run(ctx context.Context, args []string, stdout, st
 	}
 
 	pack := &packer.Pack{
-		Cfg:    cfg,
-		Output: &output,
+		FileCfg: fileCfg,
+		Cfg:     cfg,
+		Output:  &output,
 	}
 
 	pack.Main("gokrazy gok")

--- a/internal/gok/sbom.go
+++ b/internal/gok/sbom.go
@@ -58,6 +58,11 @@ func (r *sbomConfig) run(ctx context.Context, args []string, stdout, stderr io.W
 
 	updateflag.SetUpdate("yes")
 
+	// GenerateSBOM() must be provided with a cfg
+	// that hasn't been modified by gok at runtime,
+	// as the SBOM should reflect what’s going into gokrazy,
+	// not its internal implementation details
+	// (i.e.  cfg.InternalCompatibilityFlags untouched).
 	sbomMarshaled, sbomWithHash, err := packer.GenerateSBOM(cfg)
 	if os.IsNotExist(err) {
 		// Common case, handle with a good error message

--- a/internal/gok/update.go
+++ b/internal/gok/update.go
@@ -45,6 +45,11 @@ func init() {
 }
 
 func (r *updateImplConfig) run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+	fileCfg, err := config.ReadFromFile()
+	if err != nil {
+		return err
+	}
+
 	cfg, err := config.ReadFromFile()
 	if err != nil {
 		return err
@@ -77,7 +82,8 @@ func (r *updateImplConfig) run(ctx context.Context, args []string, stdout, stder
 	}
 
 	pack := &packer.Pack{
-		Cfg: cfg,
+		FileCfg: fileCfg,
+		Cfg:     cfg,
 	}
 
 	pack.Main("gokrazy gok")

--- a/internal/oldpacker/oldpacker.go
+++ b/internal/oldpacker/oldpacker.go
@@ -225,7 +225,8 @@ func logic(instanceDir string) error {
 	}
 
 	pack := &internalpacker.Pack{
-		Cfg: &cfg,
+		FileCfg: &cfg,
+		Cfg:     &cfg,
 	}
 
 	pack.Main("gokrazy packer")

--- a/internal/packer/gaf.go
+++ b/internal/packer/gaf.go
@@ -49,7 +49,12 @@ func (p *Pack) overwriteGaf(root *FileInfo) error {
 		return err
 	}
 
-	sbomMarshaled, _, err := GenerateSBOM(p.Cfg)
+	// GenerateSBOM() must be provided with a cfg
+	// that hasn't been modified by gok at runtime,
+	// as the SBOM should reflect what’s going into gokrazy,
+	// not its internal implementation details
+	// (i.e.  cfg.InternalCompatibilityFlags untouched).
+	sbomMarshaled, _, err := GenerateSBOM(p.FileCfg)
 	if err != nil {
 		return err
 	}

--- a/internal/packer/sbom.go
+++ b/internal/packer/sbom.go
@@ -48,6 +48,10 @@ type SBOMWithHash struct {
 
 // GenerateSBOM generates a Software Bills Of Material (SBOM) for the
 // local gokrazy instance.
+// It must be provided with a cfg that hasn't been modified by gok at runtime,
+// as the SBOM should reflect what’s going into gokrazy,
+// not its internal implementation details
+// (i.e.  cfg.InternalCompatibilityFlags untouched).
 func GenerateSBOM(cfg *config.Struct) ([]byte, SBOMWithHash, error) {
 	wd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
Builds on top of #65 

Fixes #64 
by adopting [approach 1](https://github.com/gokrazy/tools/issues/64#issuecomment-1772664940).

Seems to be working well for all the commands I tested: sbom, update, overwrite (full,gaf).

Testing:
```
$ make gaf 2>&1 >/dev/null
$ unzip -p /tmp/disk.gaf sbom.json | jq -r '.sbom_hash'
23c08ae3b4c009e179f46fe8e812617771c39d1540042d79c11848015dec86b9

$ make sbom | jq -r '.sbom_hash'
23c08ae3b4c009e179f46fe8e812617771c39d1540042d79c11848015dec86b9

$ make overwrite 2>&1 >/dev/null # creates a full.img
$ make test & # launches a qemu test machine from the full.img at (192.168.64.2)
$ curl -sL -H 'Accept: application/json' "http://gokrazy:$PASS@192.168.64.2/" | jq -r '.SBOMHash'
23c08ae3b4c009e179f46fe8e812617771c39d1540042d79c11848015dec86b9

$ make update
$ curl -sL -H 'Accept: application/json' "http://gokrazy:$PASS@192.168.64.2/" | jq -r '.SBOMHash'
23c08ae3b4c009e179f46fe8e812617771c39d1540042d79c11848015dec86b9

$ vim config.json
$ git diff config.json
+++ b/config.json
@@ -7,7 +7,8 @@
     },
     "Packages": [
         "github.com/gokrazy/serial-busybox",
-        "github.com/gokrazy/breakglass"
+        "github.com/gokrazy/breakglass",
+        "github.com/gokrazy/hello"

$ make sbom | jq -r '.sbom_hash'
1ab7db66f5b0a0d3253d3e104c0b375e7ae4af7449bae635c7554e0b0b596e21

$ make update
$ curl -sL -H 'Accept: application/json' "http://gokrazy:$PASS@192.168.64.2/" | jq -r '.SBOMHash'
1ab7db66f5b0a0d3253d3e104c0b375e7ae4af7449bae635c7554e0b0b596e21
```