### PR TITLE
feat: allow insecure https

### DIFF
--- a/internal/packer/packer.go
+++ b/internal/packer/packer.go
@@ -1467,7 +1467,7 @@ func (pack *Pack) logic(programName string) error {
 		done := measure.Interactively("probing https")
 		remoteScheme, err := httpclient.GetRemoteScheme(updateBaseUrl)
 		done("")
-		if remoteScheme == "https" && !tlsflag.Insecure() {
+		if remoteScheme == "https" {
 			updateBaseUrl.Scheme = "https"
 			updateflag.SetUpdate(updateBaseUrl.String())
 		}


### PR DESCRIPTION
When changing machine and forgetting to back up `~/.config/gokrazy`, you can end up in a locked state if you have SSL enabled.

Basically, running `gok update --insecure` will give, as the instance has TLS enabled:

`2024/06/03 00:17:18 updating root file system: unexpected HTTP status code: got 400 Bad Request, want 200 (body "expected a PUT request\n")`

On the other hand, not using the insecure flag will fail at certificate verification:

`2024/06/03 00:07:36 checking target partuuid support: Get "https://gokrazy:***@rpi-gokrazy/update/features": tls: failed to verify certificate: x509: certificate signed by unknown authority (possibly because of "x509: invalid signature: parent certificate cannot sign this kind of certificate" while trying to verify candidate authority certificate "gokrazy")`

If TLS is enabled, `GetRemoteScheme` gets already the correct scheme, but we should still honor the `insecure` flag if still provided (so we do not use `http`).