### PR TITLE
Support non-default FirstPartitionOffsetSectors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/breml/rootcerts v0.2.10
 	github.com/donovanhide/eventsource v0.0.0-20210830082556-c59027999da0
-	github.com/gokrazy/internal v0.0.0-20240623090836-95c24add2dd9
+	github.com/gokrazy/internal v0.0.0-20240629150625-a0f1dee26ef5
 	github.com/gokrazy/updater v0.0.0-20230215172637-813ccc7f21e2
 	github.com/google/go-cmp v0.5.9
 	github.com/google/renameio/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/breml/rootcerts v0.2.10/go.mod h1:24FDtzYMpqIeYC7QzaE8VPRQaFZU5TIUDly
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/donovanhide/eventsource v0.0.0-20210830082556-c59027999da0 h1:C7t6eeMaEQVy6e8CarIhscYQlNmw5e3G36y7l7Y21Ao=
 github.com/donovanhide/eventsource v0.0.0-20210830082556-c59027999da0/go.mod h1:56wL82FO0bfMU5RvfXoIwSOP2ggqqxT+tAfNEIyxuHw=
-github.com/gokrazy/internal v0.0.0-20240623090836-95c24add2dd9 h1:EMlaaXz9DoDmX85WJliGhulE/WpKL0F5Gnn44d8NvZU=
-github.com/gokrazy/internal v0.0.0-20240623090836-95c24add2dd9/go.mod h1:t3ZirVhcs9bH+fPAJuGh51rzT7sVCZ9yfXvszf0ZjF0=
+github.com/gokrazy/internal v0.0.0-20240629150625-a0f1dee26ef5 h1:XDklMxV0pE5jWiNaoo5TzvWfqdoiRRScmr4ZtDzE4Uw=
+github.com/gokrazy/internal v0.0.0-20240629150625-a0f1dee26ef5/go.mod h1:t3ZirVhcs9bH+fPAJuGh51rzT7sVCZ9yfXvszf0ZjF0=
 github.com/gokrazy/updater v0.0.0-20230215172637-813ccc7f21e2 h1:kBY5R1tSf+EYZ+QaSrofLaVJtBqYsVNVBWkdMq3Smcg=
 github.com/gokrazy/updater v0.0.0-20230215172637-813ccc7f21e2/go.mod h1:PYOvzGOL4nlBmuxu7IyKQTFLaxr61+WPRNRzVtuYOHw=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=

--- a/internal/packer/write.go
+++ b/internal/packer/write.go
@@ -372,7 +372,7 @@ func (p *Pack) writeBoot(f io.Writer, mbrfilename string) error {
 			return err
 		}
 		defer fmbr.Close()
-		if err := writeMBR(f.(io.ReadSeeker), fmbr, p.Partuuid); err != nil {
+		if err := writeMBR(p.FirstPartitionOffsetSectors, f.(io.ReadSeeker), fmbr, p.Partuuid); err != nil {
 			return err
 		}
 		if err := fmbr.Close(); err != nil {
@@ -594,7 +594,7 @@ func (p *Pack) writeRootDeviceFiles(f io.WriteSeeker, rootDeviceFiles []deviceco
 	return nil
 }
 
-func writeMBR(f io.ReadSeeker, fw io.WriteSeeker, partuuid uint32) error {
+func writeMBR(firstPartitionOffsetSectors int64, f io.ReadSeeker, fw io.WriteSeeker, partuuid uint32) error {
 	rd, err := fat.NewReader(f)
 	if err != nil {
 		return err
@@ -611,8 +611,8 @@ func writeMBR(f io.ReadSeeker, fw io.WriteSeeker, partuuid uint32) error {
 	if _, err := fw.Seek(0, io.SeekStart); err != nil {
 		return err
 	}
-	vmlinuzLba := uint32((vmlinuzOffset / 512) + 8192)
-	cmdlineTxtLba := uint32((cmdlineOffset / 512) + 8192)
+	vmlinuzLba := uint32((vmlinuzOffset / 512) + firstPartitionOffsetSectors)
+	cmdlineTxtLba := uint32((cmdlineOffset / 512) + firstPartitionOffsetSectors)
 
 	fmt.Printf("MBR summary:\n")
 	fmt.Printf("  LBAs: vmlinuz=%d cmdline.txt=%d\n", vmlinuzLba, cmdlineTxtLba)

--- a/packer/packer.go
+++ b/packer/packer.go
@@ -26,16 +26,18 @@ type Pack struct {
 		PieepromSHA256 string // pieeprom.sig
 		VL805SHA256    string // vl805.sig
 	}
+	FirstPartitionOffsetSectors int64
 }
 
-func NewPackForHost(hostname string) Pack {
+func NewPackForHost(firstPartitionOffsetSectors int64, hostname string) Pack {
 	h := fnv.New32a()
 	h.Write([]byte(hostname))
 	return Pack{
-		Partuuid:       h.Sum32(),
-		UsePartuuid:    true,
-		UseGPTPartuuid: true,
-		UseGPT:         true,
+		Partuuid:                    h.Sum32(),
+		UsePartuuid:                 true,
+		UseGPTPartuuid:              true,
+		UseGPT:                      true,
+		FirstPartitionOffsetSectors: firstPartitionOffsetSectors,
 	}
 }
 
@@ -94,9 +96,9 @@ var (
 
 const MB = 1024 * 1024
 
-func permSize(devsize uint64) uint32 {
-	permStart := uint32(8192 + (1100 * MB / 512))
-	permSize := uint32((devsize / 512) - 8192 - (1100 * MB / 512))
+func permSize(firstPartitionOffsetSectors int64, devsize uint64) uint32 {
+	permStart := uint32(firstPartitionOffsetSectors + (1100 * MB / 512))
+	permSize := uint32((devsize / 512) - uint64(firstPartitionOffsetSectors) - (1100 * MB / 512))
 	// LBA -33 to LBA -1 need to remain unused for the secondary GPT header
 	lastAddressable := uint32((devsize / 512) - 1) // 0-indexed
 	if lastLBA := uint32(lastAddressable - 33); permStart+permSize >= lastLBA {
@@ -105,8 +107,8 @@ func permSize(devsize uint64) uint32 {
 	return permSize
 }
 
-func PermSizeInKB(devsize uint64) uint32 {
-	permSizeLBA := permSize(devsize)
+func PermSizeInKB(firstPartitionOffsetSectors int64, devsize uint64) uint32 {
+	permSizeLBA := permSize(firstPartitionOffsetSectors, devsize)
 	permSizeBytes := permSizeLBA * 512
 	return permSizeBytes / 1024
 }
@@ -114,7 +116,7 @@ func PermSizeInKB(devsize uint64) uint32 {
 // writePartitionTable writes a Hybrid MBR: it contains the GPT protective
 // partition so that the Linux kernel recognizes the disk as GPT, but it also
 // contains the FAT32 partition so that the Raspberry Pi bootloader still works.
-func writePartitionTable(w io.Writer, devsize uint64) error {
+func writePartitionTable(firstPartitionOffsetSectors int64, w io.Writer, devsize uint64) error {
 	for _, v := range []interface{}{
 		[446]byte{}, // boot code
 
@@ -123,7 +125,7 @@ func writePartitionTable(w io.Writer, devsize uint64) error {
 		invalidCHS,
 		FAT,
 		invalidCHS,
-		uint32(8192),           // start at 8192 sectors
+		uint32(firstPartitionOffsetSectors),
 		uint32(100 * MB / 512), // 100MB in size
 
 		// Partition 2 is the protective GPT partition so that the Linux kernel
@@ -133,7 +135,7 @@ func writePartitionTable(w io.Writer, devsize uint64) error {
 		byte(0xEE),
 		invalidCHS,
 		uint32(1),
-		uint32(8191),
+		uint32(firstPartitionOffsetSectors - 1),
 
 		[16]byte{}, // partition 3
 		[16]byte{}, // partition 4
@@ -153,7 +155,7 @@ func writePartitionTable(w io.Writer, devsize uint64) error {
 // by GPT metadata. For example, Odroid HC2 clobbers sectors 1-2046 with binary blobs
 // required for booting - these devices are incompatible with GPT. See
 // https://wiki.odroid.com/odroid-xu4/software/partition_table#ubuntu_partition_table.
-func writeMBRPartitionTable(w io.Writer, devsize uint64) error {
+func writeMBRPartitionTable(firstPartitionOffsetSectors int64, w io.Writer, devsize uint64) error {
 	for _, v := range []interface{}{
 		[446]byte{}, // boot code
 
@@ -162,7 +164,7 @@ func writeMBRPartitionTable(w io.Writer, devsize uint64) error {
 		invalidCHS,
 		FAT,
 		invalidCHS,
-		uint32(8192),           // start at 8192 sectors
+		uint32(firstPartitionOffsetSectors),
 		uint32(100 * MB / 512), // 100MB in size
 
 		// Partition 2 is squash partition 1.
@@ -170,7 +172,7 @@ func writeMBRPartitionTable(w io.Writer, devsize uint64) error {
 		invalidCHS,
 		Linux,
 		invalidCHS,
-		uint32(8192 + 100*MB/512),
+		uint32(firstPartitionOffsetSectors + 100*MB/512),
 		uint32(500 * MB / 512),
 
 		// Partition 3 is squash partition 2.
@@ -178,7 +180,7 @@ func writeMBRPartitionTable(w io.Writer, devsize uint64) error {
 		invalidCHS,
 		Linux,
 		invalidCHS,
-		uint32(8192 + 600*MB/512),
+		uint32(firstPartitionOffsetSectors + 600*MB/512),
 		uint32(500 * MB / 512),
 
 		// Partition 4 is the perm partition.
@@ -186,8 +188,8 @@ func writeMBRPartitionTable(w io.Writer, devsize uint64) error {
 		invalidCHS,
 		Linux,
 		invalidCHS,
-		uint32(8192 + 1100*MB/512),
-		uint32(devsize/512 - 8192 - 1100*MB/512),
+		uint32(firstPartitionOffsetSectors + 1100*MB/512),
+		uint32(devsize/512 - uint64(firstPartitionOffsetSectors) - 1100*MB/512),
 
 		signature,
 	} {
@@ -270,7 +272,7 @@ func (p *Pack) writeGPT(w io.Writer, devsize uint64, primary bool) error {
 		Attributes uint64
 		Name       [72]byte
 	}
-	partition0First := uint64(8192)
+	partition0First := uint64(p.FirstPartitionOffsetSectors)
 	partition0Last := partition0First + (100 * MB / 512) - 1
 
 	partition1First := partition0Last + 1
@@ -280,7 +282,7 @@ func (p *Pack) writeGPT(w io.Writer, devsize uint64, primary bool) error {
 	partition2Last := partition2First + (500 * MB / 512) - 1
 
 	partition3First := partition2Last + 1
-	partition3Last := partition3First + uint64(permSize(devsize)) - 1
+	partition3Last := partition3First + uint64(permSize(p.FirstPartitionOffsetSectors, devsize)) - 1
 
 	rootType := mustParseGUID(partitionTypeLinuxRootPartitionARM64)
 	if os.Getenv("GOARCH") == "amd64" {
@@ -427,10 +429,10 @@ func (p *Pack) Partition(o *os.File, devsize uint64) error {
 		return fmt.Errorf("device is too small (at least %d MB needed, %d MB available)", minsize/MB, devsize/MB)
 	}
 	if !p.UseGPT {
-		return writeMBRPartitionTable(o, devsize)
+		return writeMBRPartitionTable(p.FirstPartitionOffsetSectors, o, devsize)
 	}
 
-	if err := writePartitionTable(o, devsize); err != nil {
+	if err := writePartitionTable(p.FirstPartitionOffsetSectors, o, devsize); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Support devices that require non-default space before the first partition starts (4MiB). Required to enable booting Rock64 devices

Related to https://github.com/gokrazy/gokrazy/issues/270