### PR TITLE
Satisfy staticcheck

### DIFF
--- a/cmd/gokr-updater/updater.go
+++ b/cmd/gokr-updater/updater.go
@@ -57,7 +57,13 @@ func main() {
 	}
 	baseUrl.Path = "/"
 	httpClient, foundMatchingCertificate, err := httpclient.GetTLSHttpClientByTLSFlag(*useTLS, *tlsInsecure, baseUrl)
+	if err != nil {
+		log.Fatal(err)
+	}
 	remoteScheme, err := httpclient.GetRemoteScheme(baseUrl)
+	if err != nil {
+		log.Fatal(err)
+	}
 	if remoteScheme == "https" {
 		baseUrl.Scheme = "https"
 		*update = baseUrl.String()

--- a/integration/gokrun_test.go
+++ b/integration/gokrun_test.go
@@ -97,8 +97,7 @@ func TestGokRun(t *testing.T) {
 		if f, ok := w.(http.Flusher); ok {
 			f.Flush()
 		}
-		for {
-		}
+		select {}
 	})
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "handler not implemented", http.StatusNotImplemented)

--- a/internal/oldpacker/oldpacker.go
+++ b/internal/oldpacker/oldpacker.go
@@ -235,7 +235,7 @@ func logic(instanceDir string) error {
 
 func Main() {
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, usage)
+		fmt.Fprint(os.Stderr, usage)
 		flag.PrintDefaults()
 		os.Exit(2)
 	}

--- a/internal/packer/buildinit.go
+++ b/internal/packer/buildinit.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"go/format"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -177,7 +176,7 @@ func (g *gokrazyInit) build() (tmpdir string, err error) {
 		return "", fmt.Errorf("PackageDirs(%s): %v", pkg, err)
 	}
 
-	tmpdir, err = ioutil.TempDir("", "gokr-packer")
+	tmpdir, err = os.MkdirTemp("", "gokr-packer")
 	if err != nil {
 		return "", err
 	}
@@ -188,7 +187,7 @@ func (g *gokrazyInit) build() (tmpdir string, err error) {
 	}
 
 	initGo := filepath.Join(tmpdir, "init.go")
-	if err := ioutil.WriteFile(initGo, b, 0644); err != nil {
+	if err := os.WriteFile(initGo, b, 0644); err != nil {
 		return "", err
 	}
 	defer os.Remove(initGo)

--- a/internal/packer/packer.go
+++ b/internal/packer/packer.go
@@ -94,9 +94,7 @@ func buildPackageMapFromFlags(cfg *config.Struct) map[string]bool {
 
 func buildPackagesFromFlags(cfg *config.Struct) []string {
 	var buildPackages []string
-	for _, pkg := range cfg.Packages {
-		buildPackages = append(buildPackages, pkg)
-	}
+	buildPackages = append(buildPackages, cfg.Packages...)
 	for _, pkg := range cfg.GokrazyPackagesOrDefault() {
 		if strings.TrimSpace(pkg) == "" {
 			continue

--- a/internal/packer/packer.go
+++ b/internal/packer/packer.go
@@ -910,7 +910,7 @@ func (ors *offsetReadSeeker) Seek(offset int64, whence int) (int64, error) {
 	return ors.ReadSeeker.Seek(offset, whence)
 }
 
-func (p *Pack) overwriteFile(filename string, root *FileInfo, rootDeviceFiles []deviceconfig.RootFile) (bootSize int64, rootSize int64, err error) {
+func (p *Pack) overwriteFile(root *FileInfo, rootDeviceFiles []deviceconfig.RootFile) (bootSize int64, rootSize int64, err error) {
 	f, err := os.Create(p.Cfg.InternalCompatibilityFlags.Overwrite)
 	if err != nil {
 		return 0, 0, err
@@ -969,30 +969,6 @@ func (p *Pack) overwriteFile(filename string, root *FileInfo, rootDeviceFiles []
 
 	return int64(bs), int64(rs), f.Close()
 }
-
-const usage = `
-gokr-packer packs gokrazy installations into SD card or file system images.
-
-Usage:
-To directly partition and overwrite an SD card:
-gokr-packer -overwrite=<device> <go-package> [<go-package>…]
-
-To create an SD card image on the file system:
-gokr-packer -overwrite=<file> -target_storage_bytes=<bytes> <go-package> [<go-package>…]
-
-To create a file system image of the boot or root file system:
-gokr-packer [-overwrite_boot=<file>|-overwrite_root=<file>] <go-package> [<go-package>…]
-
-To create file system images of both file systems:
-gokr-packer -overwrite_boot=<file> -overwrite_root=<file> <go-package> [<go-package>…]
-
-All of the above commands can be combined with the -update flag.
-
-To dump the auto-generated init source code (for use with -init_pkg later):
-gokr-packer -overwrite_init=<file> <go-package> [<go-package>…]
-
-Flags:
-`
 
 type OutputType string
 
@@ -1574,7 +1550,7 @@ func (pack *Pack) logic(programName string) error {
 				return fmt.Errorf("--target_storage_bytes must be at least %d (for boot + 2 root file systems + 100 MB /perm)", lower)
 			}
 
-			bootSize, rootSize, err = pack.overwriteFile(cfg.InternalCompatibilityFlags.Overwrite, root, rootDeviceFiles)
+			bootSize, rootSize, err = pack.overwriteFile(root, rootDeviceFiles)
 			if err != nil {
 				return err
 			}

--- a/internal/packer/packer.go
+++ b/internal/packer/packer.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -148,7 +147,7 @@ func findFlagFiles(cfg *config.Struct) (map[string][]string, error) {
 			lastModified: p.modTime,
 		})
 
-		b, err := ioutil.ReadFile(p.path)
+		b, err := os.ReadFile(p.path)
 		if err != nil {
 			return nil, err
 		}
@@ -200,7 +199,7 @@ func findBuildFlagsFiles(cfg *config.Struct) (map[string][]string, error) {
 			lastModified: p.modTime,
 		})
 
-		b, err := ioutil.ReadFile(p.path)
+		b, err := os.ReadFile(p.path)
 		if err != nil {
 			return nil, err
 		}
@@ -265,7 +264,7 @@ func findBuildTagsFiles(cfg *config.Struct) (map[string][]string, error) {
 			lastModified: p.modTime,
 		})
 
-		b, err := ioutil.ReadFile(p.path)
+		b, err := os.ReadFile(p.path)
 		if err != nil {
 			return nil, err
 		}
@@ -330,7 +329,7 @@ func findEnvFiles(cfg *config.Struct) (map[string][]string, error) {
 			lastModified: p.modTime,
 		})
 
-		b, err := ioutil.ReadFile(p.path)
+		b, err := os.ReadFile(p.path)
 		if err != nil {
 			return nil, err
 		}
@@ -488,7 +487,7 @@ func (ae *archiveExtraction) extractArchive(path string) (time.Time, error) {
 		default:
 			// TODO(optimization): do not hold file data in memory, instead
 			// stream the archive contents lazily to conserve RAM
-			b, err := ioutil.ReadAll(rd)
+			b, err := io.ReadAll(rd)
 			if err != nil {
 				return time.Time{}, err
 			}
@@ -807,7 +806,7 @@ func partitionPath(base, num string) string {
 }
 
 func verifyNotMounted(dev string) error {
-	b, err := ioutil.ReadFile("/proc/self/mountinfo")
+	b, err := os.ReadFile("/proc/self/mountinfo")
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil // platform does not have /proc/self/mountinfo, fall back to not verifying
@@ -858,7 +857,7 @@ func (p *Pack) overwriteDevice(dev string, root *FileInfo, rootDeviceFiles []dev
 		return err
 	}
 
-	tmp, err := ioutil.TempFile("", "gokr-packer")
+	tmp, err := os.CreateTemp("", "gokr-packer")
 	if err != nil {
 		return err
 	}
@@ -943,7 +942,7 @@ func (p *Pack) overwriteFile(filename string, root *FileInfo, rootDeviceFiles []
 		return 0, 0, err
 	}
 
-	tmp, err := ioutil.TempFile("", "gokr-packer")
+	tmp, err := os.CreateTemp("", "gokr-packer")
 	if err != nil {
 		return 0, 0, err
 	}
@@ -1105,7 +1104,7 @@ func (pack *Pack) logic(programName string) error {
 		return err
 	}
 
-	bindir, err := ioutil.TempDir("", "gokrazy-bins-")
+	bindir, err := os.MkdirTemp("", "gokrazy-bins-")
 	if err != nil {
 		return err
 	}
@@ -1329,7 +1328,7 @@ func (pack *Pack) logic(programName string) error {
 	}
 
 	etc := root.mustFindDirent("etc")
-	tmpdir, err := ioutil.TempDir("", "gokrazy")
+	tmpdir, err := os.MkdirTemp("", "gokrazy")
 	if err != nil {
 		return err
 	}
@@ -1595,7 +1594,7 @@ func (pack *Pack) logic(programName string) error {
 		if cfg.InternalCompatibilityFlags.OverwriteBoot != "" {
 			mbrfn := cfg.InternalCompatibilityFlags.OverwriteMBR
 			if cfg.InternalCompatibilityFlags.OverwriteMBR == "" {
-				tmpMBR, err = ioutil.TempFile("", "gokrazy")
+				tmpMBR, err = os.CreateTemp("", "gokrazy")
 				if err != nil {
 					return err
 				}
@@ -1614,13 +1613,13 @@ func (pack *Pack) logic(programName string) error {
 		}
 
 		if cfg.InternalCompatibilityFlags.OverwriteBoot == "" && cfg.InternalCompatibilityFlags.OverwriteRoot == "" {
-			tmpMBR, err = ioutil.TempFile("", "gokrazy")
+			tmpMBR, err = os.CreateTemp("", "gokrazy")
 			if err != nil {
 				return err
 			}
 			defer os.Remove(tmpMBR.Name())
 
-			tmpBoot, err = ioutil.TempFile("", "gokrazy")
+			tmpBoot, err = os.CreateTemp("", "gokrazy")
 			if err != nil {
 				return err
 			}
@@ -1630,7 +1629,7 @@ func (pack *Pack) logic(programName string) error {
 				return err
 			}
 
-			tmpRoot, err = ioutil.TempFile("", "gokrazy")
+			tmpRoot, err = os.CreateTemp("", "gokrazy")
 			if err != nil {
 				return err
 			}

--- a/internal/packer/password.go
+++ b/internal/packer/password.go
@@ -2,7 +2,6 @@ package packer
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -42,7 +41,7 @@ func ensurePasswordFileExists(hostname, defaultPassword string) (password string
 	// Save the password without a trailing \n so that xclip can be used to
 	// copy&paste the password into a browser:
 	//   % xclip < ~/.config/gokrazy/http-password.txt
-	if err := ioutil.WriteFile(filepath.Join(config.Gokrazy(), configBaseName), []byte(pw), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(config.Gokrazy(), configBaseName), []byte(pw), 0600); err != nil {
 		return "", err
 	}
 

--- a/internal/packer/poll.go
+++ b/internal/packer/poll.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 )
@@ -27,7 +27,7 @@ func pollUpdated1(ctx context.Context, updateHttpClient *http.Client, updateBase
 	if got, want := resp.StatusCode, http.StatusOK; got != want {
 		return fmt.Errorf("unexpected HTTP status code: got %d, want %d", got, want)
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/internal/packer/sbom.go
+++ b/internal/packer/sbom.go
@@ -102,7 +102,7 @@ func GenerateSBOM(cfg *config.Struct) ([]byte, SBOMWithHash, error) {
 				wd, _ := os.Getwd()
 				errStr := fmt.Sprintf("Error: build directory %q does not exist in %q\n", buildDir, wd)
 				errStr += fmt.Sprintf("Try 'gok -i %s add %s' followed by an update.\n", instanceflag.Instance(), pkg)
-				errStr += fmt.Sprintf("Afterwards, your 'gok sbom' command should work")
+				errStr += "Afterwards, your 'gok sbom' command should work"
 				return nil, SBOMWithHash{}, fmt.Errorf("%s: %w", errStr, err)
 			} else {
 				return nil, SBOMWithHash{}, err

--- a/internal/packer/write.go
+++ b/internal/packer/write.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -70,7 +69,7 @@ func copyFileSquash(d *squashfs.Directory, dest, src string) error {
 }
 
 func (p *Pack) writeCmdline(fw *fat.Writer, src string) error {
-	b, err := ioutil.ReadFile(src)
+	b, err := os.ReadFile(src)
 	if err != nil {
 		return err
 	}
@@ -130,7 +129,7 @@ linux /vmlinuz
 }
 
 func (p *Pack) writeConfig(fw *fat.Writer, src string) error {
-	b, err := ioutil.ReadFile(src)
+	b, err := os.ReadFile(src)
 	if err != nil {
 		return err
 	}

--- a/packer/gotool.go
+++ b/packer/gotool.go
@@ -83,9 +83,7 @@ func InitDeps(initPkg string) []string {
 }
 
 func BuildDir(importPath string) string {
-	if strings.HasSuffix(importPath, "/...") {
-		importPath = strings.TrimSuffix(importPath, "/...")
-	}
+	importPath = strings.TrimSuffix(importPath, "/...")
 	buildDir := filepath.Join("builddir", importPath)
 
 	// Search for go.mod from most specific to least specific directory,

--- a/packer/gotool.go
+++ b/packer/gotool.go
@@ -284,10 +284,6 @@ func (be *BuildEnv) Build(bindir string, packages []string, packageBuildFlags, p
 	done := measure.Interactively("building (go compiler)")
 	defer done("")
 
-	incompletePkgs := make([]string, 0, len(packages)+len(noBuildPackages))
-	incompletePkgs = append(incompletePkgs, packages...)
-	incompletePkgs = append(incompletePkgs, noBuildPackages...)
-
 	var eg errgroup.Group
 	for _, incompleteNoBuildPkg := range noBuildPackages {
 		buildDir, err := be.BuildDir(incompleteNoBuildPkg)

--- a/packer/packer.go
+++ b/packer/packer.go
@@ -114,7 +114,7 @@ func PermSizeInKB(devsize uint64) uint32 {
 // writePartitionTable writes a Hybrid MBR: it contains the GPT protective
 // partition so that the Linux kernel recognizes the disk as GPT, but it also
 // contains the FAT32 partition so that the Raspberry Pi bootloader still works.
-func writePartitionTable(w io.Writer, devsize uint64) error {
+func writePartitionTable(w io.Writer) error {
 	for _, v := range []interface{}{
 		[446]byte{}, // boot code
 
@@ -430,7 +430,7 @@ func (p *Pack) Partition(o *os.File, devsize uint64) error {
 		return writeMBRPartitionTable(o, devsize)
 	}
 
-	if err := writePartitionTable(o, devsize); err != nil {
+	if err := writePartitionTable(o); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
When running `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`, some problems were detected. Here is an attempt to address them all.

I grouped the commit per "kind of report" (e.g. all `ioutil` usage removed in one commit)