### PR TITLE
Preserve GOKRAZY_PARENT_DIR when executing sudo

### DIFF
--- a/internal/packer/parttable.go
+++ b/internal/packer/parttable.go
@@ -67,6 +67,7 @@ func (p *Pack) SudoPartition(path string) (*os.File, error) {
 	cmd.Env = []string{
 		"GOKR_PACKER_FD=1",
 		fmt.Sprintf("HOME=%s", os.Getenv("HOME")), // for instance config detection
+		fmt.Sprintf("GOKRAZY_PARENT_DIR=%s", os.Getenv("GOKRAZY_PARENT_DIR")), // ditto
 	}
 	cmd.Stdout = os.NewFile(uintptr(pair[1]), "")
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
In gokrazy/gokrazy#222, it was mentioned that GOKRAZY_PARENT_DIR doesn't fully work for `gok overwrite`. I tracked this down to the point where sudo is used to elevate permissions, the environment is explicitly constructed and this variable needs to be included.

Before:
```
>> env GOKRAZY_PARENT_DIR=/home/vil/code/infrastructure gok -i dns overwrite --full=/dev/sdc
gokrazy gok g41f11f on GOARCH=amd64 GOOS=linux

Build target: CGO_ENABLED=0 GOARCH=arm64 GOOS=linux
Build timestamp: 2025-01-19T15:57:52-05:00
Loading system CA certificates from /etc/ssl/certs/ca-certificates.crt
Building 6 Go packages:
…
2025/01/19 15:57:58 partitioning /dev/sdc (GPT + Hybrid MBR)
2025/01/19 15:57:58 Using sudo to gain permission to format /dev/sdc
2025/01/19 15:57:58 If you prefer, cancel and use: sudo setfacl -m u:${USER}:rw /dev/sdc
2025/01/19 15:57:58 open /home/vil/gokrazy/dns/config.json: no such file or directory
2025/01/19 15:57:58 exit status 1
```

With this patch:
```
>> env GOKRAZY_PARENT_DIR=/home/vil/code/infrastructure go run cmd/gok/gok.go -i dns overwrite --full=/dev/sdc
gokrazy gok <not okay> on GOARCH=amd64 GOOS=linux

Build target: CGO_ENABLED=0 GOARCH=arm64 GOOS=linux
Build timestamp: 2025-01-19T15:56:31-05:00
Loading system CA certificates from /etc/ssl/certs/ca-certificates.crt
Building 6 Go packages:
…
2025/01/19 15:56:38 partitioning /dev/sdc (GPT + Hybrid MBR)
2025/01/19 15:56:38 Using sudo to gain permission to format /dev/sdc
2025/01/19 15:56:38 If you prefer, cancel and use: sudo setfacl -m u:${USER}:rw /dev/sdc
2025/01/19 15:56:38 device holds 8004304896 bytes

Creating boot file system
[creating boot file system]
Kernel directory: /home/vil/go/pkg/mod/github.com/gokrazy/kernel.rpi@v0.0.0-20240623090337-52776cbb8ea3
EEPROM update summary:
  pieeprom.upd (sig dc42805eb1)
  vl805.bin (sig 548581c70a)
  recovery.bin
[done] in 0.20s, 67 MiB                           
MBR summary:
  LBAs: vmlinuz=8330 cmdline.txt=136170
  PARTUUID: da6ae8bc

Creating root file system
…
```