### PR TITLE
packer.RereadPartitions: move call to unix.Sync behind Linux conditional compile

### DIFF
--- a/packer/packer.go
+++ b/packer/packer.go
@@ -12,8 +12,6 @@ import (
 	"log"
 	"os"
 	"unicode/utf16"
-
-	"golang.org/x/sys/unix"
 )
 
 // Pack represents one pack process.
@@ -463,13 +461,9 @@ func (p *Pack) Partition(o *os.File, devsize uint64) error {
 }
 
 func (p *Pack) RereadPartitions(o *os.File) error {
-	// Make Linux re-read the partition table. Sequence of system calls like in fdisk(8).
-	unix.Sync()
-
 	if err := rereadPartitions(o); err != nil {
 		log.Printf("Re-reading partition table failed: %v. Remember to unplug and re-plug the SD card before creating a file system for persistent data, if desired.", err)
 	}
 
-	unix.Sync()
 	return nil
 }

--- a/packer/packer_linux.go
+++ b/packer/packer_linux.go
@@ -7,6 +7,9 @@ import (
 )
 
 func rereadPartitions(o *os.File) error {
+	// Make Linux re-read the partition table. Sequence of system calls like in fdisk(8).
+	unix.Sync()
+
 	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(o.Fd()), unix.BLKRRPART, 0); errno != 0 {
 		return errno
 	}
@@ -14,6 +17,8 @@ func rereadPartitions(o *os.File) error {
 	if err := o.Sync(); err != nil {
 		return err
 	}
+
+	unix.Sync()
 
 	return nil
 }


### PR DESCRIPTION
In `RereadPartitions`, move calls to `unix.Sync()` in Linux specific code as `unix.Sync()` is not portable (not available on Windows).

I'm not sure about the approach for this patch. It seems to me that the calls to `unix.Sync` is redundant with the syscall that syncs the specific partition, and so I was wondering about just removing the calls to `unix.Sync`.

Note: this is a new step in my effort to port `gok` on Windows (previous: gokrazy/internal#22).