### PR TITLE
packer: treat 404 as not-implemented for device-specific file updates

### DIFF
--- a/internal/packer/packerupdate.go
+++ b/internal/packer/packerupdate.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -144,7 +145,8 @@ func (pack *Pack) logicUpdate(ctx context.Context, isDev bool, bootSize int64, r
 			prog, f, target, fmt.Sprintf("root device file %s", rootDeviceFile.Name),
 			filepath.Join("device-specific", rootDeviceFile.Name),
 		); err != nil {
-			if errors.Is(err, updater.ErrUpdateHandlerNotImplemented) {
+			if errors.Is(err, updater.ErrUpdateHandlerNotImplemented) ||
+				strings.Contains(err.Error(), "404 Not Found") {
 				log.Printf("target does not support updating device file %s yet, ignoring", rootDeviceFile.Name)
 				continue
 			}


### PR DESCRIPTION
Older gokrazy instances do not expose the device-specific update endpoint, returning HTTP 404.  
Previously this aborted the entire OTA update before the A/B partition switch, leaving the device stuck on the old root filesystem.  
Treat 404 the same as ErrUpdateHandlerNotImplemented so the update completes.