### PR TITLE
packer: include lib/firmware from kernel package in root filesystem

### DIFF
--- a/internal/packer/packerbuild.go
+++ b/internal/packer/packerbuild.go
@@ -239,6 +239,24 @@ func (pack *Pack) logicBuild(bindir string) error {
 		lib.Dirents = append(lib.Dirents, modules)
 	}
 
+	// include lib/firmware from kernelPackage dir, if present
+	firmwareDir := filepath.Join(kernelDir, "lib", "firmware")
+	if _, err := os.Stat(firmwareDir); err == nil {
+		log.Printf("Including firmware files from:")
+		log.Printf("  %s", firmwareDir)
+		firmware := &FileInfo{
+			Filename: "firmware",
+		}
+		trace.WithRegion(context.Background(), "firmware", func() {
+			_, err = addToFileInfo(firmware, firmwareDir)
+		})
+		if err != nil {
+			return err
+		}
+		lib := root.mustFindDirent("lib")
+		lib.Dirents = append(lib.Dirents, firmware)
+	}
+
 	etc := root.mustFindDirent("etc")
 	tmpdir, err := os.MkdirTemp("", "gokrazy")
 	if err != nil {

--- a/internal/packer/packerupdate.go
+++ b/internal/packer/packerupdate.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -144,7 +145,8 @@ func (pack *Pack) logicUpdate(ctx context.Context, isDev bool, bootSize int64, r
 			prog, f, target, fmt.Sprintf("root device file %s", rootDeviceFile.Name),
 			filepath.Join("device-specific", rootDeviceFile.Name),
 		); err != nil {
-			if errors.Is(err, updater.ErrUpdateHandlerNotImplemented) {
+			if errors.Is(err, updater.ErrUpdateHandlerNotImplemented) ||
+				strings.Contains(err.Error(), "404 Not Found") {
 				log.Printf("target does not support updating device file %s yet, ignoring", rootDeviceFile.Name)
 				continue
 			}


### PR DESCRIPTION
## Summary

- Include `lib/firmware/` from the kernel package directory in the root filesystem, alongside the existing `lib/modules/` support.
- Firmware files are only included if the `lib/firmware/` directory exists in the kernel package; otherwise nothing changes.

## Motivation

Linux drivers that load firmware at runtime (e.g. WiFi drivers like `rtl8xxxu`) need firmware blobs at `/lib/firmware/`. Currently, gokrazy only copies `lib/modules/` from the kernel package into the root filesystem. There is no way to ship firmware blobs without this change.

The existing `FirmwarePackage` config field serves a different purpose (Raspberry Pi GPU bootloader blobs) and does not place files under `/lib/firmware/`.

## Testing

Tested on a Banana Pi BPI-R1 (Allwinner A20) with RTL8192CU WiFi. Firmware blobs placed in the kernel package at `lib/firmware/rtlwifi/` are correctly included in the root filesystem and loaded by the kernel at runtime.