### PR TITLE
fix: gok vm: use cpu:host on macOS with Hypervisor.framework

### DIFF
--- a/internal/gok/vmrun.go
+++ b/internal/gok/vmrun.go
@@ -175,13 +175,24 @@ func (r *vmRunConfig) runQEMU(ctx context.Context, fullDiskImage string, extraAr
 			"-m", "1024",
 		}, extraArgs...)...)
 
+	// Hardware acceleration is only available for the native architecture,
+	// e.g. arm64 for M1 MacBooks.
+	useHVF := goarch == runtime.GOARCH && runtime.GOOS == "darwin"
+	useKVM := goarch == runtime.GOARCH && runtime.GOOS == "linux"
+
 	// Start in EFI mode (not legacy BIOS) so that we get a frame buffer (for
 	// gokrazy’s fbstatus program) and serial console.
 	switch goarch {
 	case "arm64":
+		cpu := "cortex-a72"
+		if useHVF {
+			// macOS Hypervisor.framework does not support named CPU
+			// models like cortex-a72; only host and max are valid.
+			cpu = "host"
+		}
 		qemu.Args = append(qemu.Args,
 			"-machine", "virt,highmem=off",
-			"-cpu", "cortex-a72",
+			"-cpu", cpu,
 			"-bios", arm64EFI)
 
 	case "amd64":
@@ -195,15 +206,10 @@ func (r *vmRunConfig) runQEMU(ctx context.Context, fullDiskImage string, extraAr
 		)
 	}
 
-	if goarch == runtime.GOARCH {
-		// Hardware acceleration (in both cases) is only available for the
-		// native architecture, e.g. arm64 for M1 MacBooks.
-		switch runtime.GOOS {
-		case "linux":
-			qemu.Args = append(qemu.Args, "-accel", "kvm")
-		case "darwin":
-			qemu.Args = append(qemu.Args, "-accel", "hvf")
-		}
+	if useKVM {
+		qemu.Args = append(qemu.Args, "-accel", "kvm")
+	} else if useHVF {
+		qemu.Args = append(qemu.Args, "-accel", "hvf")
 	}
 
 	if !r.graphic {


### PR DESCRIPTION
macOS Hypervisor.framework (HVF) does not support named CPU models
like cortex-a72 in QEMU 10; only host and max are valid.

Use -cpu host when HVF acceleration is active and keep cortex-a72
for all other cases (Linux KVM, cross-arch software emulation).

ref: https://www.qemu.org/docs/master/system/arm/cpu-features.html