### PR TITLE
feat(packer): add compression support for extrafiles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/gokrazy/internal v0.0.0-20251208203110-3c1aa9087c82
 	github.com/gokrazy/updater v0.0.0-20250705135802-db129c40879c
 	github.com/google/renameio/v2 v2.0.0
+	github.com/klauspost/compress v1.18.6
 	github.com/mattn/go-isatty v0.0.20
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/google/renameio/v2 v2.0.0 h1:UifI23ZTGY8Tt29JbYFiuyIU3eX+RNFtUwefq9qA
 github.com/google/renameio/v2 v2.0.0/go.mod h1:BtmJXm5YlszgC+TD4HOEEUFgkJP3nLxehU6hfe7jRt4=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
+github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/packer/packer.go
+++ b/internal/packer/packer.go
@@ -4,6 +4,7 @@ package packer
 
 import (
 	"archive/tar"
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -18,6 +19,7 @@ import (
 	"github.com/gokrazy/internal/deviceconfig"
 	"github.com/gokrazy/tools/internal/log"
 	"github.com/gokrazy/tools/packer"
+	"github.com/klauspost/compress/zstd"
 )
 
 type contextKey int
@@ -93,7 +95,22 @@ func (ae *archiveExtraction) extractArchive(path string) (time.Time, error) {
 		return time.Time{}, err
 	}
 	defer f.Close()
-	rd := tar.NewReader(f)
+
+	// Sniff zstd magic bytes (0x28 0xb5 0x2f 0xfd) to transparently handle both plain tar
+	// and zstd-compressed tar archives.
+	// Ref: https://datatracker.ietf.org/doc/html/rfc8878#section-3.1.1
+	br := bufio.NewReader(f)
+	var r io.Reader = br
+	if magic, err := br.Peek(4); err == nil &&
+		magic[0] == 0x28 && magic[1] == 0xb5 && magic[2] == 0x2f && magic[3] == 0xfd {
+		zr, err := zstd.NewReader(br)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("zstd %s: %v", path, err)
+		}
+		defer zr.Close()
+		r = zr
+	}
+	rd := tar.NewReader(r)
 
 	var latestTime time.Time
 	for {
@@ -147,17 +164,23 @@ func (ae *archiveExtraction) extractArchive(path string) (time.Time, error) {
 	return latestTime, nil
 }
 
+// extraFilesArchiveCandidates returns the list of archive paths to probe
+// for a given extrafiles directory, in priority order.
+func extraFilesArchiveCandidates(dir string) []string {
+	targetArch := packer.TargetArch()
+	return []string{
+		dir + "_" + targetArch + ".tar.zst",
+		dir + "_" + targetArch + ".tar",
+		dir + ".tar.zst",
+		dir + ".tar",
+	}
+}
+
 // findExtraFilesInDir probes for extrafiles .tar files (possibly with an
 // architecture suffix like _amd64), or whether dir itself exists.
 func findExtraFilesInDir(dir string) (string, error) {
-	targetArch := packer.TargetArch()
-
 	var err error
-	for _, p := range []string{
-		dir + "_" + targetArch + ".tar",
-		dir + ".tar",
-		dir,
-	} {
+	for _, p := range append(extraFilesArchiveCandidates(dir), dir) {
 		_, err = os.Stat(p)
 		if err == nil {
 			return p, nil
@@ -179,18 +202,18 @@ func addExtraFilesFromDir(pkg, dir string, fi *FileInfo) error {
 	}
 	ae.dirs["."] = fi // root
 
-	targetArch := packer.TargetArch()
-
-	effectivePath := dir + "_" + targetArch + ".tar"
-	latestModTime, err := ae.extractArchive(effectivePath)
-	if err != nil {
-		return err
-	}
-	if len(fi.Dirents) == 0 {
-		effectivePath = dir + ".tar"
+	var (
+		effectivePath string
+		latestModTime time.Time
+		err           error
+	)
+	for _, effectivePath = range extraFilesArchiveCandidates(dir) {
 		latestModTime, err = ae.extractArchive(effectivePath)
 		if err != nil {
 			return err
+		}
+		if len(fi.Dirents) > 0 {
+			break
 		}
 	}
 	if len(fi.Dirents) == 0 {


### PR DESCRIPTION
GitHub has a hard limit of 100MB for extra files.
If these files are mostly text based (e.g. code), a quick win to circumvent this is to compress/decompress them.
This PR adds support for gzip compressed archives.