### PR TITLE
fix: gok logs: fix races happening in CI

### DIFF
--- a/internal/gok/logs.go
+++ b/internal/gok/logs.go
@@ -103,7 +103,10 @@ func (r *logsImplConfig) streamLog(ctx context.Context, w io.Writer, url string,
 	}
 	req = req.WithContext(ctx)
 
-	stream, err := eventsource.SubscribeWith("", httpClient, req)
+	// Clone the client because eventsource.SubscribeWith mutates
+	// client.CheckRedirect, and streamLog is called concurrently.
+	c := *httpClient
+	stream, err := eventsource.SubscribeWith("", &c, req)
 	if err != nil {
 		return err
 	}

--- a/internal/gok/logs.go
+++ b/internal/gok/logs.go
@@ -107,7 +107,10 @@ func (r *logsImplConfig) streamLog(ctx context.Context, w io.Writer, url string,
 	if err != nil {
 		return err
 	}
-	defer stream.Close()
+	// Do not defer stream.Close() — it races with the library's
+	// background goroutine and panics (send on closed channel).
+	// The context cancellation will abort the HTTP request, which
+	// makes the library goroutine exit on its own.
 
 	for {
 		select {

--- a/internal/gok/logs_test.go
+++ b/internal/gok/logs_test.go
@@ -1,0 +1,80 @@
+package gok
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// TestStreamLogConcurrentCancel exercises two races that existed in streamLog:
+//
+//  1. CheckRedirect data race: eventsource.SubscribeWith mutates
+//     http.Client.CheckRedirect. logsImplConfig.run calls streamLog
+//     concurrently for stdout and stderr with the same *http.Client,
+//     so both goroutines wrote to the same field. Fixed by cloning
+//     the client in streamLog before passing it to the library.
+//
+//  2. send-on-closed-channel panic: the old code deferred stream.Close(),
+//     which closes the Events/Errors channels. The library's background
+//     goroutine could still be sending on those channels after Close
+//     was called. Fixed by not calling stream.Close() at all — context
+//     cancellation aborts the HTTP request and the goroutine exits.
+//
+// Run with -race to verify both fixes.
+func TestStreamLogConcurrentCancel(t *testing.T) {
+	// Mock SSE server: streams events as fast as possible until the
+	// client disconnects (simulates a long-lived log stream).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		f, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "no flusher", http.StatusInternalServerError)
+			return
+		}
+		// Emit SSE events as fast as the client can read them.
+		// The loop never ends on its own; it only stops when the write fails
+		// after streamLog's context is canceled and the HTTP connection drops.
+		for i := 0; ; i++ {
+			_, err := fmt.Fprintf(w, "data: line %d\n\n", i)
+			if err != nil {
+				return
+			}
+			// Push each event immediately so both streamLog goroutines stay
+			// busy reading while we cancel the context below.
+			f.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	cfg := &logsImplConfig{}
+	client := srv.Client()
+
+	// Start two concurrent streamLog calls sharing the same
+	// *http.Client, mirroring how logsImplConfig.run starts
+	// stdout and stderr streams via errgroup.
+	// Under -race this detects the CheckRedirect data race (fix 1).
+	var eg errgroup.Group
+	for range 2 {
+		eg.Go(func() error {
+			return cfg.streamLog(ctx, io.Discard, srv.URL, client)
+		})
+	}
+
+	// Cancel the context while both streams are active.
+	// Before the fix, this triggered a panic in the eventsource
+	// library's background goroutine (fix 2).
+	cancel()
+
+	err := eg.Wait()
+	if err != nil && !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
This PR fixes a couple of flakes I've encountered during CI runs on this repo:

- [gok logs: don't call stream.Close() to avoid send-on-closed-channel panic](https://github.com/gokrazy/tools/pull/103/commits/2101e439848454e9b313ebdd95290c9430f30231) 
[2101e43](https://github.com/gokrazy/tools/pull/103/commits/2101e439848454e9b313ebdd95290c9430f30231)
The eventsource library's background goroutine may still be sending on
the Events/Errors channels when Close() is called, causing a panic.
Context cancellation already aborts the HTTP request, which makes the
library goroutine exit on its own.


- [gok logs: fix data race on http.Client.CheckRedirect](https://github.com/gokrazy/tools/pull/103/commits/6d2603f376c2cf626b05930aa97909a5062111ff) 
[6d2603f](https://github.com/gokrazy/tools/pull/103/commits/6d2603f376c2cf626b05930aa97909a5062111ff)
eventsource.SubscribeWith mutates the passed http.Client's
CheckRedirect field. Since streamLog is called concurrently for
stdout and stderr, this is a data race. Clone the client before
passing it to the library.
Add TestStreamLogConcurrentCancel to exercise both the concurrent
client usage and context cancellation under the race detector.